### PR TITLE
CLI: shared scripts/lib/cli.sh + clearer make errors

### DIFF
--- a/.claude/skills/divyam-tooling/SKILL.md
+++ b/.claude/skills/divyam-tooling/SKILL.md
@@ -25,9 +25,10 @@ The **Makefile is the entrypoint**. Two workflow commands cover everything; both
 
 > The **`--` is required** before args — without it `make` swallows `-l/-c/-e`-style flags (and `--long`
 > errors). `make iac`/`make k8s` forward verbatim to `./scripts/iac.sh` / `./scripts/k8s.sh`, which are
-> identical and callable directly **without** `--` — that's what the slash commands and CI use, and what
-> you run when you need per-subcommand help: `./scripts/iac.sh help`, `./scripts/k8s.sh help`. Treat the
-> scripts as the implementation; treat `make iac/k8s --` as the door. Don't invent flags — check `help`.
+> identical and callable directly **without** `--` — that's what the slash commands and CI use. For
+> help: `make <verb> -- --help` (works for every verb), or run the script directly (`./scripts/iac.sh help`,
+> `./scripts/k8s.sh help`). Treat the scripts as the implementation; treat `make iac/k8s --` as the door.
+> Don't invent flags — check `help`. A typo'd `make` verb prints a hint listing the known verbs.
 
 ## Conventions shared by both CLIs
 
@@ -36,6 +37,7 @@ The **Makefile is the entrypoint**. Two workflow commands cover everything; both
 - **Precedence:** CLI flag > pre-existing env var > `.iac.conf`/`.k8s.conf` > file default.
 - **Dry-run:** `-n` prints the command (+ `(dry-run: not executed)`); **`-y`** skips confirmations (automation only).
 - **Secrets:** the Phase-1 flow auto-sources `iac/values/secrets.env` (generate with `make iac -- secrets`). Never print its contents.
+- **Output/error presentation:** all scripts source `scripts/lib/cli.sh` — errors/status are colored `❌`/`✅`/`⚠️` lines on **stderr** (stdout stays parseable); color auto-suppresses off a TTY (so agent/CI/piped output is plain) and on `NO_COLOR=1`. `DIVYAM_NONINTERACTIVE=1` forces non-interactive. A failed `make <verb>` is attributed (`✗ 'make <verb>' failed (exit N) …`). When reading errors, the `❌` line is the root cause.
 
 ## Reference guide — load the file for the task
 

--- a/.claude/skills/divyam-tooling/references/clis.md
+++ b/.claude/skills/divyam-tooling/references/clis.md
@@ -4,7 +4,10 @@
 `make k8s -- <subcommand> [opts]` (the `--` passes flags through). These forward verbatim to
 `./scripts/iac.sh` / `./scripts/k8s.sh`, which are identical and callable directly **without** `--`
 (what the slash commands and CI use). Both print the exact command they run and accept `-n` (dry-run)
-and `-y` (skip confirms). Per-subcommand help: `make iac -- help` / `make k8s -- help`.
+and `-y` (skip confirms). Help: `make iac -- --help` / `make k8s -- --help` (or `… -- help`, or the
+script directly). All scripts share `scripts/lib/cli.sh` — errors/status are colored `❌`/`✅` lines
+on **stderr** (auto-plain off a TTY / under `NO_COLOR=1`); a failed `make <verb>` is attributed and a
+mistyped verb prints a hint.
 
 ## iac.sh subcommands — Phase 1 (Terragrunt), run as `make iac -- <subcommand>`
 
@@ -60,8 +63,18 @@ is passed raw; omit → whole stack), `-f/--filter <sel>` (raw helmfile selector
 `make iac -- plan -l 1-platform.1-k8s -c gcp`, `make k8s -- upgrade -l router`. Forgetting `--` fails
 safe (the CLI errors on the missing flag rather than acting wrongly).
 
+**Error/help behavior:** a recipe failure is attributed — `✗ 'make <verb>' failed (exit N) — … run
+'make <verb> -- --help' for usage.` (the script's own `❌` line above it is the root cause). A
+typo'd/unknown verb (e.g. `make iacc`) prints a hint listing the known verbs and exits 2 instead of
+silently no-op'ing. `make help` is colored at a TTY, plain when piped / `NO_COLOR=1`.
+
 ## Helper scripts (called by the CLIs; usable directly)
 
+- `scripts/lib/cli.sh` — **shared library, sourced (not run)** by every script: `cli::ok/warn/err/info/step`
+  (colored ❌/✅ to stderr), `cli::die [code]` (default exit 2), `cli::need_tool`, `cli::usage` (header-only
+  `--help`), `cli::validate_enum`, `cli::pick`, `cli::run`; `cli::interactive` (TTY + `!CI` + `DIVYAM_NONINTERACTIVE`).
+- `scripts/bringup.sh <run|status>` — end-to-end bringup orchestrator (see the bringup section of CLAUDE.md).
+- `scripts/status.sh` / `scripts/status-ledger.sh` — step-ledger READER (`make status`) / shared WRITER.
 - `scripts/gen-tf-env.sh --cloud <c> --env <e> [--region R --zone Z --out FILE --force]` — writes
   `iac/values/secrets.env` (TF_VAR_* + config; randomises safe secrets, leaves real ones as `FILL`).
 - `scripts/check_cloud_credentials.sh` (needs `CLOUD_PROVIDER`) — GCP ADC/SA-key or Azure SP/az-login pre-flight.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,14 @@ k8s/
   docs/cicd-overview.md            # forked-repo CI (helmfile diff) / CD (helmfile apply)
   pipeline/                        # Dockerfile + ci_validate.sh / cd_deploy.sh scaffolds
 scripts/
+  iac.sh / k8s.sh                  # Phase-1 (Terragrunt) / Phase-2 (Helmfile) workflow CLIs
+  bringup.sh / status.sh           # end-to-end bringup orchestrator / step-ledger READER
+  status-ledger.sh                 # shared ledger WRITER (sourced by bringup/iac/k8s)
+  lib/cli.sh                       # shared CLI conventions: colored ❌/✅ status to stderr,
+                                   #   cli::die/need_tool/usage/validate_enum/pick/run, human-vs-agent
+                                   #   detection (cli::interactive). Sourced by all the scripts below.
+  set-prevent-destroy.sh           # flip lifecycle.prevent_destroy across a module (backups *.pdbak)
+  install-prerequisites.sh         # install/verify the pinned toolchain (make prereqs)
   check_cloud_credentials.sh       # validates cloud auth before terragrunt
   write-outputs-yaml.sh            # TF outputs -> provider.yaml for Helm
   migration.sh                     # run before first 2-monitoring apply on existing envs
@@ -280,6 +288,12 @@ items, pauses, and verifies them before resuming** (see the `divyam-platform-eng
   `ProxyJump` encodes the 1–2 hop chain + auth). The scripts stay SSH-agnostic; never install anything
   on the VM; the engineer clones the repo + installs the toolchain manually. See
   `.claude/agents/divyam-sre.md` → "Remote operation mode".
+- **CLI conventions** (all `scripts/*.sh` source `scripts/lib/cli.sh`): errors/status print as colored
+  `❌`/`✅`/`⚠️` lines to **stderr** (stdout stays parseable); color auto-suppresses off a TTY and on
+  `NO_COLOR=1`; `DIVYAM_NONINTERACTIVE=1` forces non-interactive. A failed `make <verb>` is attributed
+  (`✗ 'make <verb>' failed (exit N) …`) and a mistyped verb prints a hint. For usage: `make <verb> -- --help`
+  (works for every verb) or run the script directly (`scripts/iac.sh --help`). When editing a script's
+  `--help`, the header is the leading comment block only (parsing stops at the first code line).
 - Always `make k8s -- diff` before `upgrade`; `install` (`sync`) only for the first install.
 - Alert-query changes should be re-proven (deploy → simulate via `test/alert-sim/*.yaml` → Zenduty
   check with `scripts/zenduty.py`) before declaring done.

--- a/Makefile
+++ b/Makefile
@@ -13,35 +13,65 @@
 
 SHELL := /usr/bin/env bash
 .DEFAULT_GOAL := help
+# Drop make's "Entering/Leaving directory" chatter so the scripts' own (colorized) output and the
+# failure summary below are what the user actually sees.
+MAKEFLAGS += --no-print-directory
 .PHONY: help iac k8s bringup status prereqs prereqs-check
 
+# Recognized verbs — used by the catch-all (%:) to tell a typo'd verb from tokens being forwarded
+# after `--`. Keep in sync with the targets above.
+KNOWN := help iac k8s bringup status prereqs prereqs-check
+
+# Forward everything after the verb (`make iac -- plan -l …` -> `scripts/iac.sh plan -l …`).
+PASS = $(filter-out $@,$(MAKECMDGOALS))
+
+# Surface a clear, attributed failure instead of just the bare `make: *** [Makefile:NN: <t>] Error N`
+# (which is what makes "make error" feel opaque). The underlying script already prints a ❌ line; this
+# adds which verb failed + how to get usage, then re-exits the real code. Append `|| $(FAIL)` to a recipe.
+# $$@ is the failing target; evaluated in the recipe shell.
+FAIL = { rc=$$?; echo "" >&2; echo "✗ 'make $@' failed (exit $$rc) — see the message above; run 'make $@ -- --help' for usage." >&2; exit $$rc; }
+
 help: ## Show this help
-	@grep -hE '^[a-zA-Z0-9_-]+:.*?## ' $(MAKEFILE_LIST) | \
-	  awk 'BEGIN{FS=":.*?## "}{printf "  \033[36m%-14s\033[0m %s\n", $$1, $$2}'
+	@c=""; r=""; if [ -t 1 ] && [ -z "$$NO_COLOR" ] && [ "$${TERM:-dumb}" != dumb ]; then c="$$(printf '\033[36m')"; r="$$(printf '\033[0m')"; fi; \
+	  grep -hE '^[a-zA-Z0-9_-]+:.*?## ' $(MAKEFILE_LIST) | \
+	  awk -v c="$$c" -v r="$$r" 'BEGIN{FS=":.*?## "}{printf "  %s%-14s%s %s\n", c, $$1, r, $$2}'
 	@echo ""
 	@echo "Put '--' before CLI args so make passes -l/-c/-e flags through:"
 	@echo "  make iac -- config -c gcp -e dev      make iac -- plan -l 1-platform.1-k8s"
 	@echo "  make k8s -- kubeconfig                make k8s -- upgrade -l router"
+	@echo ""
+	@echo "Passing flags: they MUST follow '--'  ->  make <verb> -- <flags>.  'make <verb> --help'"
+	@echo "  does NOT work (make prints its own help) — use 'make <verb> -- --help', or skip make:"
+	@echo "  scripts/<verb>.sh --help   (no '--' needed)."
 
 iac: ## Run the Phase-1 CLI, e.g. make iac -- plan -l 1-platform.1-k8s
-	@$(CURDIR)/scripts/iac.sh $(filter-out $@,$(MAKECMDGOALS))
+	@$(CURDIR)/scripts/iac.sh $(PASS) || $(FAIL)
 
 k8s: ## Run the Phase-2 CLI, e.g. make k8s -- upgrade -l router
-	@$(CURDIR)/scripts/k8s.sh $(filter-out $@,$(MAKECMDGOALS))
+	@$(CURDIR)/scripts/k8s.sh $(PASS) || $(FAIL)
 
 bringup: ## End-to-end bringup (all IaC layers + kubeconfig + helm install) / status, e.g. make bringup -- run -c azure -e sandbox -y
-	@$(CURDIR)/scripts/bringup.sh $(filter-out $@,$(MAKECMDGOALS))
+	@$(CURDIR)/scripts/bringup.sh $(PASS) || $(FAIL)
 
 status: ## Bringup progress table (scripts/status.sh, reads the step ledger), e.g. make status / make status -- -w -i 30 (watch, refresh 30s)
-	@$(CURDIR)/scripts/status.sh $(filter-out $@,$(MAKECMDGOALS))
+	@$(CURDIR)/scripts/status.sh $(PASS) || $(FAIL)
 
 prereqs: ## Install/verify the pinned toolchain (tofu, terragrunt, helm, helmfile, plugins, ...)
-	scripts/install-prerequisites.sh
+	@scripts/install-prerequisites.sh $(PASS) || $(FAIL)
 
 prereqs-check: ## Verify the toolchain only (no install; non-zero exit if gaps)
-	scripts/install-prerequisites.sh --check
+	@scripts/install-prerequisites.sh --check $(PASS) || $(FAIL)
 
-# Swallow the passthrough words (plan, -l, 1-platform.1-k8s, ...) as no-op goals so
-# `make iac -- <args>` works. Must stay last; explicit targets above take precedence.
+# Catch-all for the words after `make <verb> -- …` (they're goals to make; the verb's recipe already
+# consumed them via $(PASS)). Must stay last; explicit targets above take precedence.
+# If a real verb IS among the goals, these are forwarded flags — stay silent. If NOT (a typo'd or
+# unknown verb, the only forgotten-`--` case that reaches us — make pre-empts `--help`/`--flag`
+# itself), print a clear hint instead of silently doing nothing.
 %:
-	@:
+	@if [ -z "$(filter $(KNOWN),$(MAKECMDGOALS))" ]; then \
+	  echo "✗ '$(MAKECMDGOALS)': not a divyam-deployment command. Flags must follow a verb AND '--':" >&2; \
+	  echo "    make <verb> -- <flags>     e.g. make iac -- plan -l 1-platform   |   make k8s -- diff" >&2; \
+	  echo "  For help without '--', call the script directly:  scripts/<verb>.sh --help" >&2; \
+	  echo "  Verbs: $(KNOWN)" >&2; \
+	  exit 2; \
+	fi

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ The setup has two phases:
 ├── scripts/
 │   ├── iac.sh                      #   Phase-1 infra CLI (config/plan/apply/destroy/...)
 │   ├── k8s.sh                      #   Phase-2 stack CLI (install/upgrade/delete/status/...)
+│   ├── bringup.sh / status.sh      #   End-to-end bringup orchestrator / step-ledger reader
+│   ├── lib/cli.sh                  #   Shared CLI conventions (colored status, errors, --help)
 │   ├── set-prevent-destroy.sh      #   Flip lifecycle.prevent_destroy across a module (backups)
 │   ├── install-prerequisites.sh    #   Install/verify the pinned toolchain
 │   ├── gen-tf-env.sh               #   Generate iac/values/secrets.env
@@ -71,7 +73,8 @@ cloud login stays interactive — run `az login` / `gcloud auth login` yourself.
 > Run the workflows via `make iac -- <args>` / `make k8s -- <args>` — the **`--`** is required so make
 > passes `-l/-c/-e` flags through (e.g. `make iac -- plan -l 1-platform.1-k8s`,
 > `make k8s -- upgrade -l router`). Running `./scripts/iac.sh …` / `./scripts/k8s.sh …` directly is
-> identical and needs no `--`.
+> identical and needs no `--`. For usage, `make <verb> -- --help` (or `scripts/<verb>.sh --help`).
+> If a `make <verb>` fails it says which verb failed and the exit code; a mistyped verb prints a hint.
 
 ### Phase 1 — provision (`make iac`)
 

--- a/scripts/bringup.sh
+++ b/scripts/bringup.sh
@@ -54,14 +54,16 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SCRIPTS="$REPO_ROOT/scripts"
 CONF="$REPO_ROOT/.iac.conf"
+# shellcheck source=scripts/lib/cli.sh
+source "$SCRIPTS/lib/cli.sh"
 
 STEPS=(0-foundation 1-platform 2-app kubeconfig k8s-install)
 
 # --- arg parsing (mirrors iac.sh/k8s.sh) -----------------------------------
 SUBCMD=""; CLI_CLOUD=""; CLI_ENV=""; VALUES_DIR=""; CHANNEL=""; ART_VERSION=""
 ASSUME_YES=0; DRYRUN=0; PORCELAIN=0; WATCH=0; INTERVAL=30
-usage() { grep '^#' "$0" | grep -vE '^#(!|[[:space:]]*SPDX-)' | sed 's/^# \{0,1\}//'; }
-die() { echo "bringup.sh: $*" >&2; exit 2; }
+usage() { cli::usage "$0"; }
+die() { cli::die "$@"; }   # ❌-prefixed to stderr, exit 2 (shared lib; preserves prior exit code)
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -140,7 +142,7 @@ cmd_run() {
   "$SCRIPTS/k8s.sh" kubeconfig -c "$CLOUD" -e "$ENV_NAME" "${yn[@]}"
   if [[ "$DRYRUN" -ne 1 ]]; then
     kubectl get ns >/dev/null \
-      || { echo "bringup.sh: kubectl cannot reach the cluster with the fetched kubeconfig — refusing to run helm." >&2; exit 1; }
+      || cli::die "kubectl cannot reach the cluster with the fetched kubeconfig — refusing to run helm." 1
     echo "kubectl context: $(kubectl config current-context)"
   fi
   done_step

--- a/scripts/check_cloud_credentials.sh
+++ b/scripts/check_cloud_credentials.sh
@@ -11,10 +11,14 @@
 #   scripts/check_cloud_credentials.sh --help
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/cli.sh
+source "$SCRIPT_DIR/lib/cli.sh"
+
 case "${1:-}" in
-  -h|--help) grep '^#' "$0" | grep -vE '^#(!|[[:space:]]*SPDX-)' | sed 's/^# \{0,1\}//'; exit 0;;
+  -h|--help) cli::usage "$0"; exit 0;;
   "") ;;
-  *) echo "unknown arg: $1 (use --help)" >&2; exit 2;;
+  *) cli::die "unknown arg: $1 (use --help)";;
 esac
 
 # Validate a GCP service-account key JSON has a client_email (best-effort, tool-aware).
@@ -31,64 +35,61 @@ check_cloud_credentials() {
       # Service-account key file (e.g. CI or VM).
       if [[ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" && -f "${GOOGLE_APPLICATION_CREDENTIALS}" ]]; then
         if gcp_key_has_client_email "${GOOGLE_APPLICATION_CREDENTIALS}"; then
-          echo "GCP credentials OK (service-account key: GOOGLE_APPLICATION_CREDENTIALS)."
+          cli::ok "GCP credentials OK (service-account key: GOOGLE_APPLICATION_CREDENTIALS)."
           return 0
         fi
-        echo "Error: GOOGLE_APPLICATION_CREDENTIALS points to a file without a client_email — not a valid SA key." >&2
-        exit 1
+        cli::die "GOOGLE_APPLICATION_CREDENTIALS points to a file without a client_email — not a valid SA key." 1
       fi
       # Application Default Credentials (gcloud or other ADC).
       if ! command -v gcloud >/dev/null 2>&1; then
-        echo "Error: GCP credentials not found. Either:" >&2
+        cli::err "GCP credentials not found. Either:"
         echo "  1. Set GOOGLE_APPLICATION_CREDENTIALS to a service-account key JSON file, or" >&2
         echo "  2. Install gcloud and run: gcloud auth application-default login" >&2
         exit 1
       fi
       if ! gcloud auth application-default print-access-token >/dev/null 2>&1; then
-        echo "Error: GCP Application Default Credentials are not configured or have expired." >&2
+        cli::err "GCP Application Default Credentials are not configured or have expired."
         echo "Run: gcloud auth application-default login (or set GOOGLE_APPLICATION_CREDENTIALS)." >&2
         exit 1
       fi
       if ! gcloud projects list --limit=1 >/dev/null 2>&1; then
-        echo "Error: GCP credentials are invalid or need re-authentication." >&2
+        cli::err "GCP credentials are invalid or need re-authentication."
         echo "Run: gcloud auth login" >&2
         exit 1
       fi
-      echo "GCP credentials OK (Application Default Credentials)."
+      cli::ok "GCP credentials OK (Application Default Credentials)."
       ;;
     azure)
       # Service principal (ARM_* env vars) — preferred for non-interactive runs.
       if [[ -n "${ARM_CLIENT_ID:-}" && -n "${ARM_CLIENT_SECRET:-}" && -n "${ARM_SUBSCRIPTION_ID:-}" && -n "${ARM_TENANT_ID:-}" ]]; then
-        echo "Azure credentials OK (ARM_* service principal)."
+        cli::ok "Azure credentials OK (ARM_* service principal)."
         return 0
       fi
       # Otherwise fall back to an interactive `az login` session.
       if ! command -v az >/dev/null 2>&1; then
-        echo "Error: Azure CLI not found. Either:" >&2
+        cli::err "Azure CLI not found. Either:"
         echo "  1. Export ARM_CLIENT_ID, ARM_CLIENT_SECRET, ARM_SUBSCRIPTION_ID, ARM_TENANT_ID, or" >&2
         echo "  2. Install Azure CLI and run: az login" >&2
         exit 1
       fi
       if ! az account show >/dev/null 2>&1; then
-        echo "Error: Not logged in to Azure, or session expired." >&2
+        cli::err "Not logged in to Azure, or session expired."
         echo "Run: az login  (or export the four ARM_* service-principal variables)." >&2
         exit 1
       fi
-      echo "Azure credentials OK (az login session)."
+      cli::ok "Azure credentials OK (az login session)."
       # Informational only — an az-login session is valid; ARM_* are needed for non-interactive (CI) runs.
       local missing=""
       for v in ARM_CLIENT_ID ARM_CLIENT_SECRET ARM_SUBSCRIPTION_ID ARM_TENANT_ID; do
         [[ -z "${!v:-}" ]] && missing="${missing}${missing:+ }${v}"
       done
-      [[ -n "$missing" ]] && echo "Note: using your interactive session; for CI/non-interactive runs also set: ${missing}"
+      [[ -n "$missing" ]] && cli::info "using your interactive session; for CI/non-interactive runs also set: ${missing}"
       ;;
     "")
-      echo "Error: CLOUD_PROVIDER is not set. Set it to 'gcp' or 'azure' and re-run." >&2
-      exit 1
+      cli::die "CLOUD_PROVIDER is not set. Set it to 'gcp' or 'azure' and re-run." 1
       ;;
     *)
-      echo "Error: invalid CLOUD_PROVIDER: ${CLOUD_PROVIDER} (expected gcp|azure)." >&2
-      exit 1
+      cli::die "invalid CLOUD_PROVIDER: ${CLOUD_PROVIDER} (expected gcp|azure)." 1
       ;;
   esac
 }

--- a/scripts/gen-tf-env.sh
+++ b/scripts/gen-tf-env.sh
@@ -24,6 +24,8 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=scripts/lib/cli.sh
+source "$REPO_ROOT/scripts/lib/cli.sh"
 
 CLOUD="gcp"; ENV_NAME="dev"; OUT=""; FORCE=0; REGION_ARG=""; ZONE_ARG=""
 while [[ $# -gt 0 ]]; do
@@ -39,15 +41,15 @@ while [[ $# -gt 0 ]]; do
     --out)    OUT="$2"; shift 2;;
     --out=*)  OUT="${1#*=}"; shift;;
     --force)  FORCE=1; shift;;
-    -h|--help) grep '^#' "$0" | grep -vE '^#(!|[[:space:]]*SPDX-)' | sed 's/^# \{0,1\}//'; exit 0;;
-    *) echo "unknown arg: $1" >&2; exit 2;;
+    -h|--help) cli::usage "$0"; exit 0;;
+    *) cli::die "unknown arg: $1 (try --help)";;
   esac
 done
 
 OUT="${OUT:-$REPO_ROOT/iac/values/secrets.env}"
-case "$CLOUD" in gcp|azure) ;; *) echo "--cloud must be gcp|azure" >&2; exit 2;; esac
+cli::validate_enum --cloud "$CLOUD" gcp azure
 if [[ -e "$OUT" && "$FORCE" -ne 1 ]]; then
-  echo "refusing to overwrite existing $OUT (use --force)" >&2; exit 1
+  cli::die "refusing to overwrite existing $OUT (use --force)" 1
 fi
 mkdir -p "$(dirname "$OUT")"
 
@@ -141,12 +143,11 @@ umask 077
 } > "$OUT"
 
 chmod 600 "$OUT"
-echo "wrote ${OUT#"$REPO_ROOT"/} (chmod 600). scripts/iac.sh will auto-source it." >&2
+cli::ok "wrote ${OUT#"$REPO_ROOT"/} (chmod 600). scripts/iac.sh will auto-source it."
 # warn about empty REQUIRED reals
 if ! grep -q 'NOTIFICATION_WEBHOOK_URLS=..' "$OUT"; then
-  echo "WARN: NOTIFICATION_WEBHOOK_URLS is empty — set your Zenduty webhook before running the alert loop." >&2
+  cli::warn "NOTIFICATION_WEBHOOK_URLS is empty — set your Zenduty webhook before running the alert loop."
 fi
 if [[ "$CLOUD" == azure ]] && ! grep -q 'divyam_artifactory_docker_auth=..' "$OUT"; then
-  echo "WARN: TF_VAR_divyam_artifactory_docker_auth is empty — Azure needs it (a path to the GAR" >&2
-  echo "      dockerconfigjson file) to pull Divyam images. GCP does not." >&2
+  cli::warn "TF_VAR_divyam_artifactory_docker_auth is empty — Azure needs it (a path to the GAR dockerconfigjson file) to pull Divyam images. GCP does not."
 fi

--- a/scripts/iac.sh
+++ b/scripts/iac.sh
@@ -67,12 +67,14 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 IAC_DIR="$REPO_ROOT/iac"
 SCRIPTS="$REPO_ROOT/scripts"
 CONF="$REPO_ROOT/.iac.conf"
+# shellcheck source=scripts/lib/cli.sh
+source "$SCRIPTS/lib/cli.sh"
 
 # --- arg parsing (supports -x, --x, and --x=value) -------------------------
 SUBCMD=""; LAYER=""; FILTER=""; ASSUME_YES=0; DRYRUN=0
 CLI_CLOUD=""; CLI_ENV=""; EXTRA_ARGS=()
-usage() { grep '^#' "$0" | grep -vE '^#(!|[[:space:]]*SPDX-)' | sed 's/^# \{0,1\}//'; }
-die() { echo "iac.sh: $*" >&2; exit 2; }
+usage() { cli::usage "$0"; }
+die() { cli::die "$@"; }   # ❌-prefixed to stderr, exit 2 (shared lib; preserves prior exit code)
 
 while [[ $# -gt 0 ]]; do
   case "$1" in

--- a/scripts/install-prerequisites.sh
+++ b/scripts/install-prerequisites.sh
@@ -32,12 +32,16 @@ TERRAGRUNT_VERSION="0.99.4"
 HELMFILE_VERSION="1.4.4"
 HELM_DIFF_VERSION="3.7.0"
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/cli.sh
+source "$SCRIPT_DIR/lib/cli.sh"
+
 CHECK_ONLY=0
 case "${1:-}" in
   --check) CHECK_ONLY=1 ;;
-  -h|--help) grep '^#' "$0" | grep -vE '^#(!|[[:space:]]*SPDX-)' | sed 's/^# \{0,1\}//'; exit 0 ;;
+  -h|--help) cli::usage "$0"; exit 0 ;;
   "") ;;
-  *) echo "unknown arg: $1 (use --check or --help)" >&2; exit 2 ;;
+  *) cli::die "unknown arg: $1 (use --check or --help)" ;;
 esac
 
 INSTALL_BIN="${INSTALL_BIN:-$HOME/.local/bin}"

--- a/scripts/k8s.sh
+++ b/scripts/k8s.sh
@@ -64,14 +64,16 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 K8S_DIR="$REPO_ROOT/k8s"
 HELMFILE="$K8S_DIR/helmfile.yaml.gotmpl"
 CONF="$REPO_ROOT/.k8s.conf"
+# shellcheck source=scripts/lib/cli.sh
+source "$REPO_ROOT/scripts/lib/cli.sh"
 
 # --- arg parsing (supports -x, --x, and --x=value) -------------------------
 SUBCMD=""; RELEASE=""; FILTER=""; ASSUME_YES=0; DRYRUN=0
 STATUS_TUI=0; STATUS_DASH=0; PASSTHRU=()
 CLI_VDIR=""; CLI_ENV=""; CLI_ARTIFACTS=""; CLI_CHANNEL=""
 CLI_CLOUD=""; CLUSTER=""; PROJECT=""; REGION_F=""; ZONE_F=""; RESOURCE_GROUP=""; DO_LOGIN=0; NO_TF=0
-usage() { grep '^#' "$0" | grep -vE '^#(!|[[:space:]]*SPDX-)' | sed 's/^# \{0,1\}//'; }
-die() { echo "k8s.sh: $*" >&2; exit 2; }
+usage() { cli::usage "$0"; }
+die() { cli::die "$@"; }   # ❌-prefixed to stderr, exit 2 (shared lib; preserves prior exit code)
 
 while [[ $# -gt 0 ]]; do
   case "$1" in

--- a/scripts/lib/cli.sh
+++ b/scripts/lib/cli.sh
@@ -1,0 +1,144 @@
+# shellcheck shell=bash
+# SPDX-License-Identifier: Apache-2.0
+# scripts/lib/cli.sh — shared CLI conventions for the divyam-deployment scripts.
+#
+# Sourced (not executed) by scripts/iac.sh, k8s.sh, bringup.sh, status.sh and the helper scripts.
+# Holds the cross-cutting helpers: consistent error/status presentation, value resolution +
+# enum validation, human-vs-agent detection, and the terminal UI (color + status glyphs + one
+# spinner). The scripts keep their own hand-written `while/case` subcommand parsers and grep-based
+# `--help` — this lib just unifies how they *present* and *fail*.
+#
+#   SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"; source "$SCRIPT_DIR/lib/cli.sh"
+#
+# Human vs agent: cli::interactive is the single source of truth. A caller is "human" iff stdout
+# AND stdin are TTYs, $CI is unset, and non-interactive mode wasn't requested via
+# DIVYAM_NONINTERACTIVE=1. Agents (Claude tool shells), pipes, and CI are non-TTY -> automatically
+# non-interactive: no color, no animation, plain greppable output. Color additionally honors the
+# standard NO_COLOR opt-out (https://no-color.org).
+
+# Idempotent source guard (scripts may source transitively).
+[[ -n "${_CLI_SH_SOURCED:-}" ]] && return 0
+_CLI_SH_SOURCED=1
+
+# ------------------------------ Human vs agent --------------------------------------
+cli::interactive() {
+  [[ -t 1 && -t 0 ]]                            || return 1   # not a terminal (pipe / agent / CI capture)
+  [[ -z "${CI:-}" ]]                            || return 1   # CI environments are non-interactive
+  [[ "${DIVYAM_NONINTERACTIVE:-0}" != 1 ]]      || return 1   # explicit env override
+  return 0
+}
+
+# ------------------------------ Color palette ---------------------------------------
+# Resolved once at source time; emission is gated per-call by cli::_use_color so a non-interactive
+# context (pipe/agent/CI/NO_COLOR) discovered after sourcing still suppresses color.
+#
+# Raw SGR escapes, NOT `tput`: `tput sgr0` emits a charset-reset before `ESC [ m` that some
+# terminals mis-render and that corrupts copy/paste of aligned columns. Plain `\033[0m` resets
+# cleanly, is universally understood, and is zero display width so alignment holds.
+CLI_BOLD="" CLI_DIM="" CLI_RED="" CLI_GREEN="" CLI_YELLOW="" CLI_CYAN="" CLI_RESET=""
+if { [[ -t 1 ]] || [[ -t 2 ]]; } && [[ "${TERM:-dumb}" != dumb ]]; then
+  CLI_BOLD=$'\033[1m'
+  CLI_DIM=$'\033[2m'
+  CLI_RED=$'\033[31m'
+  CLI_GREEN=$'\033[32m'
+  CLI_YELLOW=$'\033[33m'
+  CLI_CYAN=$'\033[36m'
+  CLI_RESET=$'\033[0m'
+fi
+
+# Spinner frames: braille under a UTF-8 locale, ASCII otherwise (locale-safe slicing).
+if [[ "${LC_ALL:-}${LC_CTYPE:-}${LANG:-}" == *[Uu][Tt][Ff]* ]]; then
+  CLI_SPIN_FRAMES='⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏'
+else
+  CLI_SPIN_FRAMES='|/-\'
+fi
+
+cli::_use_color() { [[ -n "$CLI_RESET" ]] && [[ -z "${NO_COLOR:-}" ]] && cli::interactive; }
+
+# cli::_c <COLOR_VAR_NAME> <text> — wrap text in a color iff color is in play.
+cli::_c() {
+  if cli::_use_color; then printf '%s%s%s' "${!1}" "$2" "$CLI_RESET"; else printf '%s' "$2"; fi
+}
+
+# ------------------------------ Status lines ----------------------------------------
+# All go to stderr (diagnostics) so stdout stays clean/parseable. Emoji + a single subtle color.
+cli::ok()   { printf '%s %s\n' "✅" "$(cli::_c CLI_GREEN  "$*")" >&2; }
+cli::warn() { printf '%s %s\n' "⚠️ " "$(cli::_c CLI_YELLOW "$*")" >&2; }
+cli::err()  { printf '%s %s\n' "❌" "$(cli::_c CLI_RED    "$*")" >&2; }
+cli::info() { printf '%s %s\n' "ℹ️ " "$(cli::_c CLI_DIM    "$*")" >&2; }
+cli::step() { printf '%s %s\n' "$(cli::_c CLI_CYAN "▶")" "$*" >&2; }
+
+# cli::die <msg...> [code] — error line then exit. The exit code DEFAULTS TO 2 in this repo (the
+# manual parsers front both arg-parse and semantic errors through one die(), and status.sh
+# documents a 0/1/2 contract — 2 preserves every existing exit code). If the LAST argument is a
+# bare integer it's used as the exit code; otherwise all args form the message.
+cli::die() {
+  local code=2
+  if [[ $# -gt 1 && "${!#}" =~ ^[0-9]+$ ]]; then code="${!#}"; set -- "${@:1:$#-1}"; fi
+  cli::err "$*"; exit "$code"
+}
+
+# cli::need_tool <tool> [hint] — assert a command exists.
+cli::need_tool() {
+  command -v "$1" >/dev/null 2>&1 || cli::die "'$1' not found — ${2:-install it and retry}" 1
+}
+
+# cli::usage <script-file> — print the script's own comment header as help. Only the LEADING
+# comment block is used (parsing stops at the first non-comment line, i.e. `set -euo pipefail`), so
+# mid-file `#` comments — section dividers, `# shellcheck …` directives — never leak into --help.
+# The shebang and SPDX lines are dropped; a leading "# " (with optional single space) is stripped.
+cli::usage() {
+  awk '
+    !/^#/            { exit }                       # first code line ends the header
+    /^#!/            { next }                        # shebang
+    /^#[[:space:]]*SPDX-/ { next }                   # SPDX tag
+    { sub(/^#[[:space:]]?/, ""); print }
+  ' "$1"
+}
+
+# ------------------------------ Spinner ---------------------------------------------
+# cli::run "<message>" <cmd> [args...] — run cmd; at a terminal show one subtle spinner while it
+# blocks, then a final ✅/❌ line. Non-interactive: announce, run, report — no control chars.
+# Returns the command's exit code. Use for genuinely long, QUIET steps only: at a TTY the command
+# runs in the BACKGROUND so the spinner can animate, which hides any prompt/streamed output. For
+# commands that prompt or stream (terragrunt/helmfile), call them directly instead.
+cli::run() {
+  local msg="$1"; shift
+  local rc=0 _e=0; case $- in *e*) _e=1;; esac   # remember caller's errexit
+  if ! cli::interactive; then
+    cli::step "$msg"
+    set +e; "$@"; rc=$?; [[ $_e -eq 1 ]] && set -e
+    if [[ $rc -eq 0 ]]; then cli::ok "$msg"; else cli::err "$msg (exit $rc)"; fi
+    return $rc
+  fi
+  "$@" &
+  local pid=$! i=0 n="${#CLI_SPIN_FRAMES}"
+  tput civis 2>/dev/null || true
+  while kill -0 "$pid" 2>/dev/null; do
+    printf '\r%s %s' "$(cli::_c CLI_CYAN "${CLI_SPIN_FRAMES:$((i++ % n)):1}")" "$msg" >&2
+    sleep 0.1
+  done
+  set +e; wait "$pid"; rc=$?; [[ $_e -eq 1 ]] && set -e
+  tput cnorm 2>/dev/null || true
+  printf '\r\033[K' >&2                       # clear the spinner line
+  if [[ $rc -eq 0 ]]; then cli::ok "$msg"; else cli::err "$msg (exit $rc)"; fi
+  return $rc
+}
+
+# ------------------------------ Value resolution ------------------------------------
+# cli::pick <flag> <env> <conf> <default> — first non-empty of flag/env/conf, else default.
+# (4-way precedence: CLI flag > shell env > .conf value > built-in default. No prompting.)
+cli::pick() {
+  [[ -n "$1" ]] && { printf '%s' "$1"; return; }
+  [[ -n "$2" ]] && { printf '%s' "$2"; return; }
+  [[ -n "$3" ]] && { printf '%s' "$3"; return; }
+  printf '%s' "$4"
+}
+
+# cli::validate_enum <name> <value> <choice...> — die (exit 2) unless value is one of the choices.
+cli::validate_enum() {
+  local name="$1" val="$2"; shift 2
+  local c
+  for c in "$@"; do [[ "$val" == "$c" ]] && return 0; done
+  cli::die "$name must be one of: $* (got: '$val')"
+}

--- a/scripts/set-prevent-destroy.sh
+++ b/scripts/set-prevent-destroy.sh
@@ -28,10 +28,12 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 IAC_DIR="$REPO_ROOT/iac"
+# shellcheck source=scripts/lib/cli.sh
+source "$REPO_ROOT/scripts/lib/cli.sh"
 
 LAYER=""; CLOUD=""; SET_VAL=""; RUN=""; YES=0; RESTORE=0
-usage() { grep '^#' "$0" | grep -vE '^#(!|[[:space:]]*SPDX-)' | sed 's/^# \{0,1\}//'; }
-die() { echo "set-prevent-destroy.sh: $*" >&2; exit 2; }
+usage() { cli::usage "$0"; }
+die() { cli::die "$@"; }   # ❌-prefixed to stderr, exit 2 (shared lib; preserves prior exit code)
 
 while [[ $# -gt 0 ]]; do
   case "$1" in

--- a/scripts/status.sh
+++ b/scripts/status.sh
@@ -30,9 +30,11 @@ set -uo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 CONF="$REPO_ROOT/.iac.conf"
+# shellcheck source=scripts/lib/cli.sh
+source "$REPO_ROOT/scripts/lib/cli.sh"
 
-usage() { grep '^#' "$0" | grep -vE '^#(!|[[:space:]]*SPDX-)' | sed 's/^# \{0,1\}//'; }
-die() { echo "status.sh: $*" >&2; exit 2; }
+usage() { cli::usage "$0"; }
+die() { cli::die "$@"; }   # ❌-prefixed to stderr, exit 2 (shared lib; preserves prior exit code)
 
 CLI_CLOUD=""; CLI_ENV=""; PORCELAIN=0; WATCH=0; INTERVAL=30
 while [[ $# -gt 0 ]]; do

--- a/scripts/write-outputs-yaml.sh
+++ b/scripts/write-outputs-yaml.sh
@@ -11,6 +11,10 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/cli.sh
+source "$SCRIPT_DIR/lib/cli.sh"
+
 REPO_ROOT="${3:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 LAYER="${1:-${LAYER:-0}}"
 CLOUD_PROVIDER="${2:-${CLOUD_PROVIDER:-azure}}"
@@ -20,11 +24,10 @@ case "${LAYER}" in
   0) TG_DIR="0-foundation" ;;
   1) TG_DIR="1-platform" ;;
   2) TG_DIR="2-app" ;;
-  *) echo "Error: LAYER must be 0, 1, or 2 (got: ${LAYER})"; exit 1 ;;
+  *) cli::die "LAYER must be 0, 1, or 2 (got: ${LAYER})" 1 ;;
 esac
 if [[ "${CLOUD_PROVIDER}" != "azure" && "${CLOUD_PROVIDER}" != "gcp" ]]; then
-  echo "Error: CLOUD_PROVIDER must be azure or gcp (got: ${CLOUD_PROVIDER})"
-  exit 1
+  cli::die "CLOUD_PROVIDER must be azure or gcp (got: ${CLOUD_PROVIDER})" 1
 fi
 
 # Config is read from root.hcl (locals.outputs_for_helm)
@@ -78,8 +81,7 @@ esac
 TG_DIR_ABS="${REPO_ROOT}/${TG_DIR}"
 
 if [[ ! -d "${TG_DIR_ABS}" ]]; then
-  echo "Error: Layer directory not found: ${TG_DIR_ABS}"
-  exit 1
+  cli::die "Layer directory not found: ${TG_DIR_ABS}" 1
 fi
 
 # Find all directories under TG_DIR that contain terragrunt.hcl and whose path contains CLOUD_PROVIDER


### PR DESCRIPTION
## What & why

Mirrors the **shared-library + Makefile** layer of divyam-sandbox's CLI refactor into this repo, so the two repos share the same CLI *contracts* (consistent error/status presentation, attributed `make` failures, unknown-verb hints, NO_COLOR/agent-aware output, unified `--help`).

Deliberately **excludes argbash**: divyam-sandbox is flat verb-per-script, but this repo's `iac.sh`/`k8s.sh`/`bringup.sh` are **subcommand dispatchers** (`plan`/`apply`/`destroy`/`import`/…) that argbash can't model. The existing hand-written `while/case` parsers and the `--` pass-through are kept as-is. **No existing exit codes change.**

## Changes

- **`scripts/lib/cli.sh`** (new, sourced by every script): `cli::ok/warn/err/info/step` (colored `❌`/`✅`/`⚠️` to **stderr**), `cli::die [code]` (default exit 2 — preserves this repo's prior contract; sandbox uses 1), `cli::need_tool`, `cli::usage` (header-only `--help`), `cli::pick`, `cli::validate_enum`, `cli::run`; `cli::interactive` (TTY + `!CI` + `DIVYAM_NONINTERACTIVE`). Raw-SGR color, auto-suppressed off a TTY and under `NO_COLOR`.
- **`Makefile`**: `FAIL` macro attributes which `make <verb>` failed and re-exits the real code; a `KNOWN`-verb catch-all hints on a typo'd verb instead of a silent no-op; `--no-print-directory`; NO_COLOR/TTY-aware `help`.
- **All `scripts/*.sh`** source the lib and present errors/status consistently. `--help` now renders the leading comment block only (no more leaked mid-file `# shellcheck …` / section-divider comments).
- **Docs**: `CLAUDE.md` (layout tree + a CLI-conventions bullet), `README.md`, and the `divyam-tooling` skill (`SKILL.md` + `references/clis.md`).

## Verification

- `bash -n` clean on the lib + all 9 edited scripts.
- Typo'd verb (`make iacc`) → verb hint, exit 2; unknown subcommand → `❌` + `✗ 'make iac' failed (exit 2) … run 'make iac -- --help'`.
- Bad enum → `❌ --cloud must be one of: gcp azure (got: 'bogus')`, exit 2.
- **0 ESC bytes** in piped/non-TTY output (color correctly suppressed); `NO_COLOR` honored.
- Forwarded flags don't trip the catch-all hint when a known verb is present.
- `make <verb> -- --help` → exit 0 for all five verbs; `--help` output no longer leaks mid-file comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)