### PR TITLE
feat(stack): evalm8|router|both stack selector (helmfile + iac)

### DIFF
--- a/iac/values/defaults.hcl
+++ b/iac/values/defaults.hcl
@@ -10,6 +10,14 @@ locals {
   region            = get_env("REGION","centralindia")
   zone              = get_env("ZONE","centralindia-1")
 
+  # Stack selector: which Divyam stack this deployment provisions.
+  # Allowed values are "evalm8", "router", or "both" (the default).
+  # This mirrors the helmfile STACK selector so IaC and Helm pick the same stack.
+  # Units read it as local.root.stack to gate evalm8-only cloud resources.
+  # No evalm8-only IaC resources exist today (all infra is shared), so this gates nothing yet.
+  # When evalm8-only resources are added, gate their unit with exclude { if = local.root.stack == "router" }.
+  stack             = get_env("STACK", "both")
+
   deployment_mode = "onprem"  # Set value to "managed" | "onprem"
 
   deployment_prefix = (

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -179,6 +179,7 @@ kubectl get ns
 |----------|----------|---------|-------------|
 | `HELMFILE_VALUES_DIR` | No | `.` (current directory) | Path to the directory containing your values files. |
 | `ARTIFACTS_VERSION` | No | _(unset)_ | When set, loads `releases/<VERSION>-artifacts.yaml` instead of `artifacts.yaml`. |
+| `STACK` | No | `both` | Which stack to deploy: `evalm8`, `router`, or `both`. Falls back to `settings.stack` in `resources.yaml`. Mirrors the iac `stack` selector. |
 ---
 
 ## 2. Expected Directory Structure
@@ -238,6 +239,26 @@ make k8s -- upgrade -d /path/to/values  # point at a different values directory
 ```bash
 make k8s -- upgrade -l clickhouse     # → helmfile -l name=clickhouse-<env> apply
 ```
+
+### Selecting a Stack (evalm8 / router / both)
+
+The platform ships two stacks: the **router** ecosystem (router-controller, route-selector,
+selector-training, evaluator, clickhouse, kafka, superset, and so on) and the **evalm8** stack
+(evalm8 apps with their temporal, lakefs, and argilla datastores and operators). `external-secrets`,
+`mysql`, and persistent storage are shared and always deploy.
+
+Pass `--stack` to bring up only one stack. The default is `both`. The same selector exists in the iac
+`stack` variable, so infrastructure and Helm pick the same stack.
+
+```bash
+make k8s -- install --stack evalm8    # only the evalm8 stack (+ shared infra)
+make k8s -- upgrade --stack router    # only the router stack (+ shared infra)
+make k8s -- diff    --stack evalm8    # preview just one stack
+STACK=evalm8 helmfile list            # raw helmfile: list the selected releases
+```
+
+A persistent default for an environment can be set as `settings.stack` in `resources.yaml`. The
+`--stack` flag and the `STACK` env var override it.
 
 ### Preview Changes
 

--- a/k8s/helm-values/sample-resources.yaml
+++ b/k8s/helm-values/sample-resources.yaml
@@ -1,6 +1,7 @@
 settings:
   use_spot_nodes: true
   storage_class: economyHdd   # Possible values: economyHdd, standardSsd, premiumSsd
+  # stack: both               # Which stack to deploy: evalm8 | router | both. Override with STACK env or --stack.
 
 charts:
   divyam-persistent-storage:

--- a/k8s/helmfile.yaml.gotmpl
+++ b/k8s/helmfile.yaml.gotmpl
@@ -4,6 +4,7 @@
 #   helmfile diff
 #   helmfile -l name=mysql apply
 #   helmfile destroy
+#   STACK=evalm8 helmfile list    # select only one stack: evalm8 | router | both (default both)
 
 helmDefaults:
   createNamespace: true
@@ -136,6 +137,16 @@ repositories:
 {{- $clusterDomain := $values.global.clusterDomain }}
 {{- $externalSecretsChartName := "external-secrets/external-secrets" }}
 
+{{/* Stack selector: evalm8 | router | both. Gates which release groups are enabled so a single
+     invocation brings up only the selected stack. Precedence: STACK env var, then STACK_SELECTOR
+     env var, then resources.yaml settings.stack, then "both". The matching terraform variable
+     gates the evalm8 cloud resources in iac/, so both phases select the same stack. */}}
+{{- $stack := env "STACK" | default (env "STACK_SELECTOR") | default (dig "stack" "both" $settings) }}
+{{- if not (has $stack (list "evalm8" "router" "both")) }}
+{{- fail (printf "ERROR: invalid stack selector '%s'. Set STACK (or settings.stack) to one of: evalm8, router, both." $stack) }}
+{{- end }}
+{{- $_ := exec "sh" (list "-c" (printf "echo '[INFO] stack selector: %s' >&2" $stack)) }}
+
 ###############################################################################
 # 2. Namespace Group Map
 ###############################################################################
@@ -187,6 +198,52 @@ repositories:
   "evalm8-ingress"                        "evalm8"
 
 -}}
+
+###############################################################################
+# 2b. Stack Membership (drives the stack selector)
+###############################################################################
+{{/*
+  Namespace groups that belong to the Evalm8 stack: the Evalm8 apps, their datastores
+  (temporal, lakefs, argilla), and the operators those datastores need (CNPG, OpenSearch,
+  Redis). Every group not listed here is treated as router/platform.
+*/}}
+{{- $evalm8Groups := dict
+  "evalm8"                      true
+  "temporal"                    true
+  "lakefs"                      true
+  "argilla"                     true
+  "cnpg-system"                 true
+  "opensearch-operator-system"  true
+  "redis-operator-system"       true
+-}}
+
+{{/*
+  Charts shared by both stacks, always enabled regardless of the selector. External Secrets
+  resolves cloud secrets for every workload, mysql is the platform database that both the
+  router services and evalm8-server/wfs use, and persistent storage backs both.
+*/}}
+{{- $sharedCharts := dict
+  "external-secrets-operator"   true
+  "mysql"                       true
+  "divyam-persistent-storage"   true
+-}}
+
+{{/*
+  Per-chart stack membership. A chart is selected when the stack is "both", when it is a shared
+  chart, or when its namespace group matches the selected stack (evalm8 groups for "evalm8",
+  everything else for "router"). A chart's group is namespaceGroupMap[name] or its own name.
+*/}}
+{{- $stackEnabled := dict }}
+{{- range $cName, $_cfg := $values.charts }}
+  {{- $grp := index $namespaceGroupMap $cName | default $cName }}
+  {{- $isEvalm8 := hasKey $evalm8Groups $grp }}
+  {{- $sel := false }}
+  {{- if eq $stack "both" }}{{- $sel = true }}
+  {{- else if hasKey $sharedCharts $cName }}{{- $sel = true }}
+  {{- else if eq $stack "evalm8" }}{{- $sel = $isEvalm8 }}
+  {{- else }}{{- $sel = (not $isEvalm8) }}{{- end }}
+  {{- $_ := set $stackEnabled $cName $sel }}
+{{- end }}
 
 {{/*
   Charts that receive a top-level `ingress` value merged from provider.yaml
@@ -378,6 +435,8 @@ releases:
          chart marked `enabled: false`. Default to true only when the key is absent. */ -}}
   {{- $enabled := true }}
   {{- if hasKey ($rawCfg | default dict) "enabled" }}{{- $enabled = (index ($rawCfg | default dict) "enabled") }}{{- end }}
+  {{- /* Stack selector gate: a chart not in the selected stack is treated as disabled. */ -}}
+  {{- if not (index $stackEnabled $name) }}{{- $enabled = false }}{{- end }}
   {{- if $enabled }}
 
     {{- $chart := printf "%s/%s" $base $name }}
@@ -414,6 +473,7 @@ releases:
       {{- /* Same explicit-flag gating as above (mergo would re-enable an enabled:false dep). */ -}}
       {{- $depEnabled := true }}
       {{- if hasKey $depRaw "enabled" }}{{- $depEnabled = (index $depRaw "enabled") }}{{- end }}
+      {{- if not (index $stackEnabled $depName) }}{{- $depEnabled = false }}{{- end }}
       {{- if $depEnabled }}
 
         {{- $depNs := include "namespace" (dict
@@ -464,9 +524,11 @@ releases:
       {{- $depCfg := merge (dict "enabled" true "values" dict "namespace" nil) $depRaw }}
 
       {{- /* Only emit a need for a dep that is actually enabled. A disabled dep has no
-             release, so listing it as a need is an undefined-release error in helmfile. */ -}}
+             release, so listing it as a need is an undefined-release error in helmfile.
+             A dep outside the selected stack is disabled too, so its need is dropped. */ -}}
       {{- $depEnabled := true }}
       {{- if hasKey $depRaw "enabled" }}{{- $depEnabled = (index $depRaw "enabled") }}{{- end }}
+      {{- if not (index $stackEnabled $dep) }}{{- $depEnabled = false }}{{- end }}
       {{- if $depEnabled }}
 
         {{- $depNs := include "namespace" (dict

--- a/scripts/k8s.sh
+++ b/scripts/k8s.sh
@@ -32,6 +32,8 @@
 #                           / .k8s.conf / helmfile default). With -C, resolves within that channel.
 #   -C, --channel <stable|nightly>  Set ARTIFACTS_CHANNEL -> releases/<channel>/<-a|latest>-artifacts.yaml.
 #                           Omit to use a local artifacts.yaml or stable/latest. See k8s/releases/VERSIONING.md.
+#       --stack <evalm8|router|both>  Set STACK -> select only that stack's releases (default both).
+#                           Mirrors the iac stack selector. Falls back to $STACK, then settings.stack.
 #       --tui                 status: open the helm-tui terminal UI (`helm tui`).
 #       --dashboard           status: open the helm-dashboard web UI (`helm dashboard`).
 #   kubeconfig options (resolved from iac/values/secrets.env + provider.yaml when omitted):
@@ -70,7 +72,7 @@ source "$REPO_ROOT/scripts/lib/cli.sh"
 # --- arg parsing (supports -x, --x, and --x=value) -------------------------
 SUBCMD=""; RELEASE=""; FILTER=""; ASSUME_YES=0; DRYRUN=0
 STATUS_TUI=0; STATUS_DASH=0; PASSTHRU=()
-CLI_VDIR=""; CLI_ENV=""; CLI_ARTIFACTS=""; CLI_CHANNEL=""
+CLI_VDIR=""; CLI_ENV=""; CLI_ARTIFACTS=""; CLI_CHANNEL=""; CLI_STACK=""
 CLI_CLOUD=""; CLUSTER=""; PROJECT=""; REGION_F=""; ZONE_F=""; RESOURCE_GROUP=""; DO_LOGIN=0; NO_TF=0
 usage() { cli::usage "$0"; }
 die() { cli::die "$@"; }   # ❌-prefixed to stderr, exit 2 (shared lib; preserves prior exit code)
@@ -89,6 +91,8 @@ while [[ $# -gt 0 ]]; do
     --artifacts-version=*)  CLI_ARTIFACTS="${1#*=}"; shift;;
     -C|--channel) CLI_CHANNEL="${2:?--channel needs a value}"; shift 2;;
     --channel=*)  CLI_CHANNEL="${1#*=}"; shift;;
+    --stack)      CLI_STACK="${2:?--stack needs a value}"; shift 2;;
+    --stack=*)    CLI_STACK="${1#*=}"; shift;;
     --tui)        STATUS_TUI=1; shift;;
     --dashboard)  STATUS_DASH=1; shift;;
     -c|--cloud)   CLI_CLOUD="${2:?--cloud needs a value}"; shift 2;;
@@ -125,6 +129,9 @@ VALUES_DIR="${CLI_VDIR:-${HELMFILE_VALUES_DIR:-${CONF_VDIR:-k8s/helm-values}}}"
 ENV_OVERRIDE="${CLI_ENV:-${ENV:-$CONF_ENV}}"
 ARTIFACTS_VERSION="${CLI_ARTIFACTS:-${ARTIFACTS_VERSION:-$CONF_ARTIFACTS}}"
 ARTIFACTS_CHANNEL="${CLI_CHANNEL:-${ARTIFACTS_CHANNEL:-$CONF_CHANNEL}}"
+# Stack selector: flag, then $STACK, else empty (helmfile falls back to settings.stack, then both).
+STACK="${CLI_STACK:-${STACK:-}}"
+case "$STACK" in ""|evalm8|router|both) ;; *) die "--stack must be one of: evalm8, router, both (got '$STACK')";; esac
 # Channel/version are passed through `make k8s -- …`; reject `=` (make would eat NAME=VALUE as a var).
 case "${ARTIFACTS_CHANNEL}${ARTIFACTS_VERSION}" in *=*) die "channel/version must be plain tokens (no '=')";; esac
 # Accept an absolute --values-dir (e.g. an out-of-repo dir like the sandbox's sky_workdir values);
@@ -175,6 +182,7 @@ hf() {  # <diff|sync|apply|destroy|template> [extra args...]
   local -a cmd=(helmfile -f "$HELMFILE" "${SEL[@]}" "$verb" "$@" "${PASSTHRU[@]}")
   local ctx="env=${ENV_NAME:-<auto>}"; [[ -n "$ARTIFACTS_VERSION" ]] && ctx+=" ARTIFACTS_VERSION=$ARTIFACTS_VERSION"
   [[ -n "$ARTIFACTS_CHANNEL" ]] && ctx+=" ARTIFACTS_CHANNEL=$ARTIFACTS_CHANNEL"
+  [[ -n "$STACK" ]] && ctx+=" STACK=$STACK"
   echo "+ (cd $VALUES_DIR && ${cmd[*]})   [$ctx]"
   [[ "$DRYRUN" -eq 1 ]] && { echo "  (dry-run: not executed)"; return 0; }
   # Export the ABSOLUTE values dir: helmfile resolves `readFile` in helmfile.yaml.gotmpl relative to
@@ -183,6 +191,7 @@ hf() {  # <diff|sync|apply|destroy|template> [extra args...]
   ( cd "$BASE" && export HELMFILE_VALUES_DIR="$BASE"; \
     [[ -n "$ARTIFACTS_VERSION" ]] && export ARTIFACTS_VERSION; \
     [[ -n "$ARTIFACTS_CHANNEL" ]] && export ARTIFACTS_CHANNEL; \
+    [[ -n "$STACK" ]] && export STACK; \
     "${cmd[@]}" )
 }
 


### PR DESCRIPTION
Implements the **stack-flag** item of #52: a single `stack` selector (`evalm8` | `router` | `both`) in both the helmfile and the iac, so one deploy brings up only the selected stack.

Stacked on #54 (base `ft/evalm8-helm-charts`), because the evalm8 release wiring it gates lands in #54. Rebases onto `main` once #54 merges.

## What changed

**Helmfile (`k8s/helmfile.yaml.gotmpl`)**
- Resolve the stack from `STACK` env var, then `STACK_SELECTOR`, then `settings.stack` in `resources.yaml`, defaulting to `both`. An invalid value fails the render with a clear message.
- Classify each chart by its namespace group. The evalm8 groups own the evalm8 apps, their temporal/lakefs/argilla datastores, and the CNPG/OpenSearch/Redis operators. `external-secrets`, `mysql`, and persistent storage are shared and always on. Every other chart is router.
- Gate the release loop, the dependency-DNS map, and the `needs:` emission by stack membership, so a release outside the selected stack is never rendered or referenced as a need.

**CLI (`scripts/k8s.sh`)**
- Add a `--stack` flag that validates the value and exports `STACK` to helmfile. Usable as `make k8s -- install --stack evalm8`.

**IaC (`iac/values/defaults.hcl`)**
- Add a `stack` local from `get_env("STACK", "both")`, read by units as `local.root.stack`. There are no evalm8-only cloud resources today (a grep for evalm8/lakefs/argilla/temporal across `iac/` is empty), so it gates nothing yet. A future evalm8-only unit gates with `exclude { if = local.root.stack == "router" }`. This keeps the iac and helmfile selecting the same stack.

**Docs**
- `STACK` in `k8s/README.md` (env-var table + a "Selecting a Stack" section) and the helmfile usage header, plus the `settings.stack` option in `sample-resources.yaml`.

## Verification (`helmfile list` against the full sample-resources chart set)

| stack | releases |
|-------|----------|
| `both` (default) | 37 — **identical to the pre-change release set**, so the default is a no-op |
| `evalm8` | 18 (evalm8 apps + datastores + 3 operators + 3 shared) |
| `router` | 22 (router/platform + 3 shared) |

- `union(evalm8, router) == both`, and the only overlap is the 3 shared charts (`external-secrets`, `mysql`, persistent storage). No release is lost or duplicated.
- `settings.stack` is honored when no env var is set, and `STACK` overrides it.
- An invalid value fails loudly in both the helmfile (`fail`) and `k8s.sh` (`die`).
- `--stack` is dry-run tested: it exports `STACK` and validates, and absence defaults to `both`.

## Notes
- Acceptance per #52: `helmfile -e <env> list` (here `STACK=<v> helmfile list`, since the env is read from `provider.yaml`) under each flag value shows only the expected releases. Confirmed above.
- The default path is byte-identical to the current behavior, so this does not change the green sandbox bring-up.

Refs: #52