### PR TITLE
releases: rename release-block source_sha -> build-id

### DIFF
--- a/k8s/releases/VERSIONING.md
+++ b/k8s/releases/VERSIONING.md
@@ -61,7 +61,7 @@ Two layers, kept deliberately small:
      version: <this file's id>
      base: <target stable core>        # nightly: the target; stable: == version
      created: <RFC3339 UTC>
-     source_sha: <build/source git sha>
+     build-id: <pipeline run id; "manually seeded" for hand-seeded files>
      seq: <int>                        # nightly only
      promoted_from: <nightly id>       # stable only — the exact nightly that became this stable
    ```
@@ -90,7 +90,7 @@ A consumer can keep its local `artifacts.yaml` as default and opt into a channel
 ## Pipeline obligations (for the future, not-yet-built pipeline)
 
 - **Nightly run:** read `NEXT_VERSION`=base; id = `<base>-nightly.<UTCdate>.<seq>` (seq monotonic/day);
-  write `nightly/<id>-artifacts.yaml` (schema + scalar `release:` with `source_sha`); **append a row to
+  write `nightly/<id>-artifacts.yaml` (schema + scalar `release:` with `build-id`); **append a row to
   `index.yaml`**; on passing gates, atomically (write-temp-then-`mv`) update `nightly/latest`=id.
 - **Promotion (nightly → stable):** input nightly id `N`, target stable `S` (= `base` of `N`). Copy
   `nightly/N-artifacts.yaml` → `stable/S-artifacts.yaml` **byte-for-byte** (image tags & chart versions

--- a/k8s/releases/index.yaml
+++ b/k8s/releases/index.yaml
@@ -6,7 +6,7 @@ releases:
     channel: stable
     base: "1.0.0"
     created: "2026-06-07T00:00:00Z"
-    source_sha: genesis
+    build-id: genesis
     # genesis stable: hand-seeded, no nightly predecessor (no promoted_from).
   - version: "1.0.1-nightly.20260619.1"
     channel: nightly

--- a/k8s/releases/stable/1.0.0-artifacts.yaml
+++ b/k8s/releases/stable/1.0.0-artifacts.yaml
@@ -7,7 +7,7 @@ release:
   version: "1.0.0"
   base: "1.0.0"
   created: "2026-06-07T16:17:09Z"
-  source_sha: genesis-repin
+  build-id: genesis-repin
 
 chartBasePath: "oci://asia-south1-docker.pkg.dev/prod-benchmarking/divyam-public-helm-as1"
 


### PR DESCRIPTION
Follow-up to #69.

#69 introduced `build-id` on the new nightly artifact and its `index.yaml` row, but `VERSIONING.md` and the pre-existing genesis artifacts still used `source_sha`. This renames the `release:`-block field everywhere so the contract and all artifacts agree.

## Changes

- `VERSIONING.md` — `release:` schema (`source_sha: <git sha>` → `build-id: <pipeline run id; "manually seeded" for hand-seeded files>`) + the nightly pipeline obligation wording.
- `stable/1.0.0-artifacts.yaml` — `source_sha: genesis-repin` → `build-id: genesis-repin`.
- `index.yaml` — genesis stable row `source_sha: genesis` → `build-id: genesis`.

`build-id` carries the nightly pipeline run id; hand-seeded files use `"manually seeded"`. Genesis releases keep their `genesis`/`genesis-repin` sentinels (still informative).

After this, `grep -rn source_sha k8s/releases/` returns nothing — the field name is consistent across the contract, both index rows, and both artifacts files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)