### PR TITLE
k8s: 'make k8s -- diagnose' + opt-in deploy-override flags (failure debug artifact)

### DIFF
--- a/.claude/skills/divyam-tooling/references/infra-ops.md
+++ b/.claude/skills/divyam-tooling/references/infra-ops.md
@@ -1,0 +1,179 @@
+# Divyam infra operations (datastores & pipeline) — SRE reference
+
+Cluster-maintenance playbook for the Divyam stateful/infra components: **health checks, data-flow
+debugging, alerts (P0/P1), and deploy/scale ops**. Pairs with `debugging.md` (helm/release failures),
+`kubectl.md`, `helm-helmfile.md`, `known-gotchas.md`. The **developer** half (knobs, schema/table
+conventions, dos & don'ts) lives in the `divyam-sandbox` harness `infra-<x>` skills — this file is the
+**operator** half the `divyam-sre` agent uses.
+
+> **Known instabilities** are tracked centrally in the `divyam-sandbox` harness
+> `docs/architecture/known-gaps.md` (by ID, e.g. `G-MYSQL-HA`, `G-OTEL-BUFFER`). Reference those IDs
+> here rather than re-describing — keep this file drift-free.
+
+Conventions: kubeconfig first (`make k8s -- kubeconfig`). Namespaces `<chart>-<env>-ns`; releases
+`<chart>-<env>`. Scale/resources are set in the **k8s-values `resources.yaml`** the helmfile reads, then
+`make k8s -- upgrade -l <chart> -d <values-dir>` (diff first). Alerts are defined in
+`iac/2-app/2-alerts/common/rules/*.json` → only `CRITICAL` notifies Zenduty.
+
+---
+
+## ClickHouse  (analytics/OLAP · billing- & training-critical · Altinity operator)
+Cluster `clk-<env>` (CHI + keeper CHK) in `clickhouse-<env>-ns`; svc `clk-<env>-service` (HTTP 8123,
+native 9000); keeper 2181/9444. Ingests from Kafka (`router-raw-logs`, `router-metering-logs`) via
+Kafka-engine tables (consumer group `clickhouse_consumer_group`, 5 consumers).
+
+### Health
+```bash
+kubectl get pods -n clickhouse-<env>-ns                 # CHI + keeper pods Ready
+kubectl get chi,chk -n clickhouse-<env>-ns              # Altinity CRs Completed/Reconciled
+make k8s -- status | grep clickhouse                    # release deployed
+clickhouse-client -q "SELECT database,table,is_readonly,absolute_delay,queue_size FROM system.replicas"
+clickhouse-client -q "SELECT * FROM system.kafka"       # Kafka-engine consumers attached?
+```
+
+### Data-flow debugging (is telemetry landing?)
+```bash
+clickhouse-client -q "SELECT max(timestamp) FROM divyam_router_logs.raw_logs_dist"        # recent?
+clickhouse-client -q "SELECT max(timestamp) FROM divyam_router_logs.divyam_metering_data_dist"
+# lag rising but no rows → check Kafka side (see Kafka section) + that the MV/Kafka table exist
+clickhouse-client -q "SELECT count() FROM system.merges"   # merge backlog
+df -h (in pod) / kubectl describe pvc -n clickhouse-<env>-ns   # disk
+```
+
+### P0 (page) / P1 (warn)
+- **P0:** Kafka-engine ingestion stalled / consumer lag growing (→ billing+training blocked); keeper
+  quorum lost (writes/DDL fail); replica `is_readonly=1`; disk ≥ ~85% / `MergeTreePartsToThrowInsert`.
+- **P1:** merge backlog rising, replication `queue_size`/`absolute_delay` growing, query latency,
+  MV/insert errors, memory pressure. (Metrics via 8123 / managed-Prometheus; alerts in `2-alerts`.)
+
+### Runbooks
+- **Ingestion stalled:** 1) ClickHouse pod logs for consumer errors; 2) `SELECT * FROM system.kafka`
+  (table attached? MV present? a recent `db-upgrades` may have detached it → recreate); 3) check Kafka
+  health (under-ISR/offline); 4) check parts/disk. Restore in that order.
+- **Keeper quorum lost:** check CHK pods; restore the keeper StatefulSet — replicas are read-only until
+  quorum returns. Keep keeper count **odd**.
+- **Read-only replica:** check keeper connectivity + ZK path; `SYSTEM RESTART REPLICA db.table`.
+- **Disk full:** confirm TTL applied; `OPTIMIZE`/drop old parts; **expand PVC** (`persistence.size`) →
+  `make k8s -- upgrade -l clickhouse`.
+
+### Deploy / scale ops
+- Scale: edit k8s-values `resources.yaml` (replicas/cpu/mem/storage) → `make k8s -- diff` →
+  `upgrade -l clickhouse`. Resharding (`shardsCount`) is heavy — plan data redistribution.
+- Upgrade: bump the Altinity image tag; the operator rolls. Test `db-upgrades` against the new server
+  first. Back up before destructive ops.
+- Capacity/gaps: keeper single-replica in some envs (no HA) — **(confirm per env)**.
+
+---
+
+## Kafka (Strimzi/KRaft)  (async telemetry transport · off request path)
+Cluster `kafka-<env>-cluster` in `kafka-<env>-ns`; bootstrap `kafka-<env>-cluster-kafka-bootstrap…:9092`.
+Producers: OTEL. Consumers: ClickHouse Kafka-engine (group `clickhouse_consumer_group`) + kafka-connect.
+
+### Health / data-flow
+```bash
+kubectl get kafka,kafkanodepool,kafkatopic -n kafka-<env>-ns      # Strimzi CRs Ready
+kubectl get pods -n kafka-<env>-ns | grep -vE 'Running|Completed'
+# in a broker pod: topic end-offsets growing? consumer-group lag?
+bin/kafka-consumer-groups.sh --bootstrap-server :9092 --describe --group clickhouse_consumer_group
+```
+### P0 / P1
+- **P0:** `UnderMinIsrPartitionCount>0` / `OfflinePartitionsCount>0` (producers blocked → OTEL buffers →
+  loss); active-controller≠1 (KRaft quorum); broker log-dir/disk full.
+- **P1:** consumer lag rising, under-replicated partitions, frequent leader elections, produce latency.
+  (JMX→Prometheus :9404; alerts in `2-alerts`.)
+### Runbooks
+- **Under-ISR/offline:** recover the down broker (`kubectl get pods`); **never delete broker PVCs**; ISR
+  self-heals on rejoin. **Disk full:** enforce retention / expand PVC → `make k8s -- upgrade -l kafka-cluster`.
+  **Controller quorum:** check KRaft controller pods. **Connect DLQ growing:** check connector + cloud creds/WIF.
+### Deploy / scale
+- k8s-values `resources.yaml`: broker replicas / storage / cpu-mem; topic partitions (raise with
+  ClickHouse `kafka_num_consumers`). Keep rf=3 / min.isr=2. Rolling upgrade via Strimzi — never force-delete.
+
+---
+
+## OTEL Collector  (telemetry ingress · billing-critical on buffer overflow)
+`otel-collector-<env>-ns`; metrics :8181, healthz :13133. Router → OTLP :4617/:4618 → routing → Kafka.
+
+### Health / data-flow
+```bash
+kubectl get pods -n otel-collector-<env>-ns
+curl -s <otel-svc>:13133/healthz
+curl -s <otel-svc>:8181/metrics | grep -E 'otelcol_exporter_(sent|send_failed)|otelcol_exporter_queue'
+```
+### P0 / P1
+- **P0:** collector down (router can't ship telemetry); `file_storage` disk near full while Kafka is
+  down (imminent **data loss**); `memory_limiter` refusing (`otelcol_processor_refused_*`).
+- **P1:** Kafka export retries/`send_failed`, `otelcol_exporter_queue_size`→`_capacity`, receiver refused.
+### Runbooks
+- **Down:** restart; check OOM (raise memory / `memory_limiter`). Router serving unaffected; telemetry
+  resumes from the disk buffer. **Export failing:** fix Kafka first; the buffer drains on recovery —
+  **act before the 10Gi `file_storage` fills**. **Buffer full:** restore Kafka / expand the PVC.
+### Deploy / scale
+- k8s-values `resources.yaml`: replicas, memory (+`memory_limiter.limit_mib`), `file_storage` size.
+  Keep `producer.max_message_bytes` == Kafka `message.max.bytes` (268MB).
+
+---
+
+## Qdrant  (vector store · serving-relevant when a selector is live)
+`qdrant-<env>-ns`; svc `qdrant-<env>-svc` (6333 http / 6334 grpc); `/metrics` on 6333.
+
+### Health / data-flow
+```bash
+kubectl get pods -n qdrant-<env>-ns                     # qdrant-<env>-sts Ready
+curl -s <qdrant-svc>:6333/healthz ; curl -s <qdrant-svc>:6333/collections   # collection per selector_id, status green
+```
+### P0 / P1
+- **P0:** Qdrant down (selector inference fails for live selectors — confirm router fallback), disk full,
+  a live selector's collection red/missing. **P1:** search-latency P95, memory near limit (HNSW OOM risk).
+### Runbooks
+- **Down:** restart (`qdrant-<env>-sts`); check PVC + node memory. **Collection missing/corrupt:**
+  re-promote the selector (selector-training writes embeddings); restore from snapshot only if enabled.
+  **Disk full:** expand PVC; clean inactive selectors' collections (training cleans — verify it ran).
+### Deploy / scale
+- k8s-values `resources.yaml`: **memory first** (HNSW is RAM-resident), storage, replicas/cluster (heavier).
+
+---
+
+## Redis  (offline cache for training/eval · NOT serving-critical)
+`redis-<env>` Deployment; svc `redis-<env>-service` :6379. Standalone, AOF. **No metrics exporter (gap).**
+
+### Health
+```bash
+kubectl get pods -n <redis-ns> ; kubectl exec <redis-pod> -- redis-cli ping
+kubectl exec <redis-pod> -- redis-cli info memory   # used_memory vs maxmemory, evictions
+```
+### P0 / P1
+- **P0:** low (offline). Closest: AOF disk full (bounded to training/eval, not serving).
+- **P1:** Redis down → selector-training/evaluator re-call LLMs (**cost spike**); memory near `maxmemory`
+  / high eviction (low hit-rate → cost). No exporter → use the training/eval LLM-cost signal as a proxy.
+### Runbooks
+- **Down:** restart — cache rebuilds on misses (no data loss; no serving impact). **Memory/evictions:**
+  set/raise `maxmemory` + eviction policy. **AOF disk full:** expand PVC, or disable AOF (confirm).
+### Deploy / scale
+- k8s-values `resources.yaml`: memory + `maxmemory` + eviction (`allkeys-lru`), storage. HA not wired.
+
+---
+
+## MySQL  (router metadata DB · serving-critical · single-node SPOF)
+`mysql-<env>-ns`; svc `mysql-<env>-svc` :3306; DB `divyam-<env>`; creds via external-secrets
+(`mysql-<env>-credentials`). Datadog monitoring user bootstrapped via a Job.
+
+### Health / data-flow
+```bash
+kubectl get pods -n mysql-<env>-ns                      # mysql-<env>-sts Ready
+mysql -h mysql-<env>-svc -uroot -p -e "SELECT 1; SHOW STATUS LIKE 'Threads_connected'; SHOW VARIABLES LIKE 'max_connections';"
+```
+### P0 / P1
+- **P0:** MySQL down (router serves cached keys via stale-while-error, but **new lookups + all writes
+  fail**; training/cli blocked); disk full; connections exhausted ("Too many connections").
+- **P1:** slow queries, long-running locks/transactions, buffer-pool pressure. (Datadog MySQL check; no
+  mysqld_exporter — gap.)
+### Runbooks
+- **Down:** restart `mysql-<env>-sts`; check PVC. **No failover (single node)** — restore the pod/PVC;
+  communicate that new onboarding/lookups are impacted until restored. **Disk full:** expand PVC + prune.
+  **Too many connections:** find the source (router pool / runaway client); raise `max_connections` as a
+  stopgap. **SQLAlchemy attribute error:** apply the additive migration FIRST, then restart (libs rule).
+### Deploy / scale
+- k8s-values `resources.yaml`: cpu/mem (buffer pool), storage, `max_connections`. **Back up before any
+  upgrade (single node).** **Reliability gap: no replication/failover for a serving-critical store —
+  candidate for an HA change.**

--- a/k8s/helmfile.yaml.gotmpl
+++ b/k8s/helmfile.yaml.gotmpl
@@ -6,11 +6,15 @@
 #   helmfile destroy
 # Stack selection (evalm8 | router | both) comes from the `stack` key in provider.yaml. Absent = all.
 
+# wait/timeout/atomic are env-overridable so a caller (e.g. the sandbox / nightly CI) can relax them
+# for faster failure + surviving wreckage to diagnose. Unset env ⇒ the prod defaults below verbatim —
+# the prod path never sets these vars, so its behavior is unchanged. Set by k8s.sh's --no-wait /
+# --deploy-timeout / --no-atomic flags (exported as HF_WAIT / HF_TIMEOUT / HF_ATOMIC).
 helmDefaults:
   createNamespace: true
-  wait: true
-  timeout: 1200
-  atomic: true
+  wait: {{ env "HF_WAIT" | default "true" }}
+  timeout: {{ env "HF_TIMEOUT" | default "1200" }}
+  atomic: {{ env "HF_ATOMIC" | default "true" }}
   diffArgs:
     - "--normalize-manifests"
     - "--three-way-merge"

--- a/scripts/k8s-diagnose.sh
+++ b/scripts/k8s-diagnose.sh
@@ -1,0 +1,250 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# k8s-diagnose.sh — capture a structured "why did the deploy fail" artifact from a live cluster.
+#
+# Invoked by `scripts/k8s.sh diagnose` (and reusable directly). Snapshots the failing helm releases
+# and unhealthy pods into a self-contained bundle + a machine-readable summary.json, derives a
+# best-effort verdict, and redacts secret-shaped strings. Read-only against the cluster; ALWAYS
+# exits 0 (it is a reporter, not a gate) so it never changes a caller's exit code.
+#
+# Consumers: a human (`make k8s -- diagnose`), the divyam-sandbox `box` CLI (pulls the bundle to the
+# laptop + enriches it with component/repo/ref), and the nightly CI pipeline (ships it as an
+# artifact). The summary.json schema is the shared contract — see SCHEMA below.
+#
+# Portability: needs only helm + kubectl + jq (already required wherever helmfile deploys), NOT
+# python — so any client deploying the stack can run it.
+#
+# Usage: k8s-diagnose.sh --out-dir <dir> [--release <chart>] [--env <name>] [--command "<str>"]
+#                        [--exit-code <n>] [--error-log <file>]
+#   --release/--env  scope to one release (name=<chart>-<env>); omit to scan the whole stack.
+#   --command/--exit-code/--error-log  context from the failed `make k8s -- upgrade` (recorded in
+#                        summary.json .helm; --error-log's tail feeds the HELM_RENDER/TIMEOUT rules).
+set -uo pipefail   # NOT -e: a diagnostic must keep going past individual probe failures.
+
+OUT_DIR=""; REL_CHART=""; ENV_NAME=""; HELM_CMD=""; HELM_RC=""; ERROR_LOG=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --out-dir)    OUT_DIR="${2:?}"; shift 2;;
+    --release)    REL_CHART="${2:-}"; shift 2;;
+    --env)        ENV_NAME="${2:-}"; shift 2;;
+    --command)    HELM_CMD="${2:-}"; shift 2;;
+    --exit-code)  HELM_RC="${2:-}"; shift 2;;
+    --error-log)  ERROR_LOG="${2:-}"; shift 2;;
+    *) echo "k8s-diagnose: ignoring unknown arg: $1" >&2; shift;;
+  esac
+done
+[[ -n "$OUT_DIR" ]] || { echo "k8s-diagnose: --out-dir is required" >&2; exit 0; }
+
+have() { command -v "$1" >/dev/null 2>&1; }
+if ! have kubectl || ! have helm || ! have jq; then
+  echo "k8s-diagnose: need kubectl + helm + jq on PATH; skipping capture" >&2
+  exit 0
+fi
+
+mkdir -p "$OUT_DIR/releases" "$OUT_DIR/workloads" "$OUT_DIR/pods" "$OUT_DIR/events" 2>/dev/null || true
+TS="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+# --- redaction: mask secret-shaped values in captured text -------------------------------------
+# Best-effort, conservative: values of env/keys whose name screams secret, plus long base64/hex
+# blobs and bearer tokens. Operates on stdin -> stdout. Mirrors the intent of ci_deploy's redactor
+# (the python side reuses that util; this is the bash-only deploy path which can't import it).
+redact() {
+  sed -E \
+    -e 's/((PASS|PASSWORD|SECRET|TOKEN|APIKEY|API_KEY|ACCESS_KEY|PRIVATE_KEY|CREDENTIAL|AUTH)[A-Z0-9_]*["'"'"']?[[:space:]]*[:=][[:space:]]*["'"'"']?)[^[:space:]"'"'"']+/\1***REDACTED***/Ig' \
+    -e 's/(Bearer[[:space:]]+)[A-Za-z0-9._-]+/\1***REDACTED***/Ig' \
+    -e 's/([A-Za-z0-9+\/]{40,}={0,2})/***REDACTED***/g'
+}
+# Write stdin to a file, redacted. Usage: <cmd> | save <relpath>
+save() { redact > "$OUT_DIR/$1" 2>/dev/null || true; }
+
+# --- 1) helm releases: failing ones (or the targeted one) --------------------------------------
+ALL_REL="$(helm list -A -o json 2>/dev/null || echo '[]')"
+TARGET_REL=""; [[ -n "$REL_CHART" && -n "$ENV_NAME" ]] && TARGET_REL="${REL_CHART}-${ENV_NAME}"
+
+# A release is "failing" if status != deployed, OR it is the explicitly targeted release.
+FAILING_REL="$(printf '%s' "$ALL_REL" | jq -c --arg t "$TARGET_REL" \
+  '[ .[] | select((.status != "deployed") or (.name == $t)) ]' 2>/dev/null || echo '[]')"
+
+# Namespaces to inspect: the failing releases' namespaces (+ scan-all when nothing targeted).
+declare -a NSES=()
+while IFS= read -r ns; do [[ -n "$ns" ]] && NSES+=("$ns"); done < <(printf '%s' "$FAILING_REL" | jq -r '.[].namespace' 2>/dev/null | sort -u)
+
+# Capture helm status/history for each failing release.
+while IFS=$'\t' read -r rname rns; do
+  [[ -z "$rname" ]] && continue
+  helm status "$rname" -n "$rns" 2>&1 | save "releases/${rns}__${rname}.status.txt"
+  helm history "$rname" -n "$rns" 2>&1 | save "releases/${rns}__${rname}.history.txt"
+done < <(printf '%s' "$FAILING_REL" | jq -r '.[] | [.name,.namespace] | @tsv' 2>/dev/null)
+
+# --- 2) pods: unhealthy ones in the relevant namespaces ----------------------------------------
+# Pull pod json for the target namespaces (or all if none resolved), then keep the unhealthy ones:
+# not Running/Succeeded phase, OR a container not ready / waiting with a reason / terminated nonzero.
+if [[ "${#NSES[@]}" -gt 0 ]]; then
+  PODS_JSON='{"items":[]}'
+  for ns in "${NSES[@]}"; do
+    one="$(kubectl get pods -n "$ns" -o json 2>/dev/null || echo '{"items":[]}')"
+    PODS_JSON="$(jq -s '{items: (.[0].items + .[1].items)}' <(printf '%s' "$PODS_JSON") <(printf '%s' "$one") 2>/dev/null || printf '%s' "$PODS_JSON")"
+  done
+else
+  PODS_JSON="$(kubectl get pods -A -o json 2>/dev/null || echo '{"items":[]}')"
+fi
+
+UNHEALTHY="$(printf '%s' "$PODS_JSON" | jq -c '
+  [ .items[]
+    | select(
+        (.status.phase != "Running" and .status.phase != "Succeeded")
+        or ([ (.status.containerStatuses // [])[] | select(.ready != true) ] | length > 0)
+        or ([ (.status.containerStatuses // [])[] | select((.restartCount // 0) > 0) ] | length > 0)
+      )
+    | {
+        name: .metadata.name,
+        namespace: .metadata.namespace,
+        phase: .status.phase,
+        ready: ([ (.status.containerStatuses // [])[] | .ready ] | all),
+        restarts: ([ (.status.containerStatuses // [])[] | (.restartCount // 0) ] | add // 0),
+        containers: [ (.status.containerStatuses // [])[] | {
+            name: .name,
+            image: .image,
+            ready: .ready,
+            state: (.state | keys[0] // "unknown"),
+            reason: (.state.waiting.reason // .state.terminated.reason // null),
+            message: (.state.waiting.message // .state.terminated.message // null),
+            last_terminated: (if .lastState.terminated then
+                {reason: .lastState.terminated.reason, exit_code: .lastState.terminated.exitCode}
+              else null end)
+          } ]
+      }
+  ]' 2>/dev/null || echo '[]')"
+
+# Per-pod evidence files (describe / logs / previous logs), all redacted.
+while IFS=$'\t' read -r pns pname; do
+  [[ -z "$pname" ]] && continue
+  kubectl describe pod "$pname" -n "$pns" 2>&1 | save "pods/${pns}__${pname}.describe.txt"
+  kubectl logs "$pname" -n "$pns" --all-containers --tail=200 2>&1 | save "pods/${pns}__${pname}.logs.txt"
+  kubectl logs "$pname" -n "$pns" --all-containers --previous --tail=200 2>/dev/null | save "pods/${pns}__${pname}.logs-previous.txt"
+done < <(printf '%s' "$UNHEALTHY" | jq -r '.[] | [.namespace,.name] | @tsv' 2>/dev/null)
+
+# Attach a short event list + log tail to each pod record (for summary.json), and dump full events.
+for ns in "${NSES[@]:-}"; do
+  [[ -z "$ns" ]] && continue
+  kubectl get events -n "$ns" --sort-by=.lastTimestamp 2>&1 | save "events/${ns}.events.txt"
+done
+
+enrich_pod() {  # adds events[] + log_tail + log_previous + files{} to one pod json record
+  local rec="$1" pns pname ev lt lp
+  pns="$(printf '%s' "$rec" | jq -r '.namespace')"
+  pname="$(printf '%s' "$rec" | jq -r '.name')"
+  ev="$(kubectl get events -n "$pns" --field-selector "involvedObject.name=$pname" \
+        --sort-by=.lastTimestamp -o json 2>/dev/null \
+        | jq -c '[ .items[] | "\(.reason): \(.message)" ] | .[-8:]' 2>/dev/null || echo '[]')"
+  lt="$(tail -c 4000 "$OUT_DIR/pods/${pns}__${pname}.logs.txt" 2>/dev/null | jq -Rs . 2>/dev/null || echo '""')"
+  lp="$(tail -c 4000 "$OUT_DIR/pods/${pns}__${pname}.logs-previous.txt" 2>/dev/null | jq -Rs . 2>/dev/null || echo '""')"
+  printf '%s' "$rec" | jq -c \
+    --argjson ev "$ev" --argjson lt "$lt" --argjson lp "$lp" \
+    --arg dsc "pods/${pns}__${pname}.describe.txt" --arg lg "pods/${pns}__${pname}.logs.txt" \
+    '. + {events: $ev, log_tail: $lt, log_previous: $lp, files: {describe: $dsc, logs: $lg}}' 2>/dev/null \
+    || printf '%s' "$rec"
+}
+ENRICHED="[]"
+while IFS= read -r rec; do
+  [[ -z "$rec" || "$rec" == "null" ]] && continue
+  one="$(enrich_pod "$rec")"
+  ENRICHED="$(jq -c --argjson o "$one" '. + [$o]' <(printf '%s' "$ENRICHED") 2>/dev/null || printf '%s' "$ENRICHED")"
+done < <(printf '%s' "$UNHEALTHY" | jq -c '.[]' 2>/dev/null)
+
+# --- 3) workloads: rollout conditions for the relevant namespaces ------------------------------
+WORKLOADS="[]"
+for ns in "${NSES[@]:-}"; do
+  [[ -z "$ns" ]] && continue
+  w="$(kubectl get deploy,statefulset,job -n "$ns" -o json 2>/dev/null \
+    | jq -c --arg ns "$ns" '[ .items[]
+        | { kind: .kind, name: .metadata.name, namespace: $ns,
+            ready: (((.status.readyReplicas // .status.ready // 0) | tostring) + "/" + ((.spec.replicas // 1) | tostring)),
+            conditions: [ (.status.conditions // [])[] | select(.status != "True") | {type: .type, reason: (.reason // ""), message: (.message // "")} ] }
+        | select(.conditions | length > 0) ]' 2>/dev/null || echo '[]')"
+  WORKLOADS="$(jq -c -s 'add' <(printf '%s' "$WORKLOADS") <(printf '%s' "$w") 2>/dev/null || printf '%s' "$WORKLOADS")"
+  kubectl get deploy,statefulset,job -n "$ns" -o wide 2>&1 | save "workloads/${ns}.txt"
+done
+
+# --- 4) error tail from the failed upgrade -----------------------------------------------------
+ERR_TAIL=""
+[[ -n "$ERROR_LOG" && -f "$ERROR_LOG" ]] && ERR_TAIL="$(tail -n 40 "$ERROR_LOG" 2>/dev/null | redact)"
+
+# --- 5) verdict cascade (first match wins; order = severity) -----------------------------------
+# Reads the enriched pods + error tail. Pure field/string matching — every verdict is traceable.
+N_PODS="$(printf '%s' "$ENRICHED" | jq 'length' 2>/dev/null || echo 0)"
+reasons() { printf '%s' "$ENRICHED" | jq -r '.[].containers[].reason // empty' 2>/dev/null; }
+match_reason() { reasons | grep -qiE "$1"; }
+ev_match()    { printf '%s' "$ENRICHED" | jq -r '.[].events[]? // empty' 2>/dev/null | grep -qiE "$1"; }
+err_match()   { printf '%s' "$ERR_TAIL" | grep -qiE "$1"; }
+
+CLASS="UNKNOWN"; ROOT=""
+first_pod_with() {  # echo "<pod>\t<ns>\t<ctr>\t<reason>\t<exit>" for the first pod whose container reason matches $1
+  printf '%s' "$ENRICHED" | jq -r --arg re "$1" '
+    .[] as $p | $p.containers[] | select((.reason // "") | test($re;"i"))
+    | [$p.name, $p.namespace, .name, (.reason // ""), ((.last_terminated.exit_code // "") | tostring)] | @tsv' 2>/dev/null | head -1
+}
+
+if err_match 'YAML parse|template:|admission webhook|denied the request|immutable|invalid value|failed to create|conversion' && [[ "$N_PODS" -eq 0 ]]; then
+  CLASS="HELM_RENDER"
+  ROOT="release render/apply failed: $(printf '%s' "$ERR_TAIL" | grep -iE 'error|denied|invalid|immutable' | head -1 | cut -c1-160)"
+elif match_reason 'ImagePullBackOff|ErrImagePull|InvalidImageName'; then
+  CLASS="IMAGE_PULL"
+  IFS=$'\t' read -r p ns _ r _ < <(first_pod_with 'ImagePullBackOff|ErrImagePull|InvalidImageName')
+  img="$(printf '%s' "$ENRICHED" | jq -r --arg p "$p" '.[] | select(.name==$p) | .containers[] | select(.reason|test("Image";"i")) | .image' 2>/dev/null | head -1)"
+  ROOT="${p}: ${r} pulling ${img}"
+elif match_reason 'CreateContainerConfigError|CreateContainerError|RunContainerError' || ev_match 'couldn.t find key|secret .* not found|configmap .* not found|not synced'; then
+  CLASS="CONFIG_ERROR"
+  IFS=$'\t' read -r p ns _ r _ < <(first_pod_with 'CreateContainerConfigError|CreateContainerError|RunContainerError')
+  ROOT="${p:-a pod}: ${r:-config/secret error} — see pods/${ns}__${p}.describe.txt"
+elif match_reason 'CrashLoopBackOff' || printf '%s' "$ENRICHED" | jq -e '[.[].containers[] | select((.last_terminated.exit_code // 0) != 0)] | length > 0' >/dev/null 2>&1; then
+  CLASS="CRASH_LOOP"
+  IFS=$'\t' read -r p ns c r ec < <(first_pod_with 'CrashLoopBackOff')
+  [[ -z "$p" ]] && IFS=$'\t' read -r p ns c < <(printf '%s' "$ENRICHED" | jq -r '.[] as $p | $p.containers[] | select((.last_terminated.exit_code // 0) != 0) | [$p.name,$p.namespace,.name] | @tsv' 2>/dev/null | head -1)
+  ROOT="${p}/${c}: CrashLoopBackOff${ec:+, last exit $ec} — see pods/${ns}__${p}.logs-previous.txt"
+elif printf '%s' "$ENRICHED" | jq -e '[.[] | select(.phase=="Pending")] | length > 0' >/dev/null 2>&1 && ev_match 'FailedScheduling|Insufficient|didn.t match|untolerated taint|unbound|no nodes available'; then
+  CLASS="SCHEDULING"
+  p="$(printf '%s' "$ENRICHED" | jq -r '[.[] | select(.phase=="Pending")][0].name' 2>/dev/null)"
+  why="$(printf '%s' "$ENRICHED" | jq -r '.[].events[]? // empty' 2>/dev/null | grep -iE 'FailedScheduling|Insufficient|untolerated|unbound' | head -1 | cut -c1-160)"
+  ROOT="${p}: Pending — ${why}"
+elif ev_match 'Readiness probe failed|Liveness probe failed|Unhealthy'; then
+  CLASS="PROBE_FAILURE"
+  p="$(printf '%s' "$ENRICHED" | jq -r '.[0].name' 2>/dev/null)"
+  ROOT="${p}: readiness/liveness probe failing — see pods/ describe + logs"
+elif err_match 'timed out waiting|context deadline exceeded|DeadlineExceeded'; then
+  CLASS="TIMEOUT_UNKNOWN"
+  ROOT="deploy timed out waiting for readiness; no clear pod-level cause captured"
+fi
+[[ -z "$ROOT" ]] && ROOT="deploy failed; ${N_PODS} unhealthy pod(s) captured — inspect the bundle"
+
+# --- 6) assemble summary.json (the contract) ---------------------------------------------------
+REL_SUMMARY="$(printf '%s' "$FAILING_REL" | jq -c '[ .[] | {name, namespace, status, revision: (.revision|tostring)} ]' 2>/dev/null || echo '[]')"
+FAILED_RELEASE="$(printf '%s' "$FAILING_REL" | jq -r '.[0].name // ""' 2>/dev/null)"
+
+jq -n \
+  --arg ts "$TS" --arg env "$ENV_NAME" \
+  --arg selector "${REL_CHART:-all}" \
+  --arg class "$CLASS" --arg root "$ROOT" --arg failed_release "$FAILED_RELEASE" \
+  --arg cmd "$HELM_CMD" --arg rc "$HELM_RC" --arg errtail "$ERR_TAIL" \
+  --argjson releases "$REL_SUMMARY" \
+  --argjson workloads "$WORKLOADS" \
+  --argjson pods "$ENRICHED" \
+  --arg bundle "$OUT_DIR" \
+  '{
+    schema_version: 1,
+    timestamp: $ts,
+    stage: "deploy",
+    trigger: "failure",
+    env: $env,
+    selector: $selector,
+    verdict: { classification: $class, root_cause: $root, failed_release: $failed_release },
+    helm: { command: $cmd, exit_code: ($rc | tonumber? // null), error_tail: $errtail, releases: $releases },
+    workloads: $workloads,
+    pods: $pods,
+    bundle_dir: $bundle
+  }' > "$OUT_DIR/summary.json" 2>/dev/null \
+  || echo '{"schema_version":1,"stage":"deploy","verdict":{"classification":"UNKNOWN","root_cause":"summary assembly failed; see bundle files"}}' > "$OUT_DIR/summary.json"
+
+echo "k8s-diagnose: ${CLASS} — ${ROOT}"
+echo "k8s-diagnose: bundle written to ${OUT_DIR} (summary.json + releases/ pods/ workloads/ events/)"
+exit 0

--- a/scripts/k8s.sh
+++ b/scripts/k8s.sh
@@ -16,6 +16,8 @@
 #   install           First install — helmfile sync (installs ALL releases). Auto-diffs first.
 #   upgrade           Routine upgrade — helmfile apply (only changed). Auto-diffs first.
 #   delete            Uninstall — helmfile destroy (type-to-confirm)
+#   diagnose          Capture a failure artifact (failing releases + unhealthy pods + verdict) to
+#                     -o/--out-dir (default ~/sandbox-run/debug/<ts>); summary.json + bundle. Exits 0.
 #   template          Render manifests locally (append `-- --debug` to pass flags to helm)
 #   status            Show release state: `helm ls -A`, then optionally the TUI or web dashboard
 #   kubeconfig        Authenticate to the cloud and (re)fetch cluster kubeconfig (alias: auth)
@@ -32,6 +34,12 @@
 #                           / .k8s.conf / helmfile default). With -C, resolves within that channel.
 #   -C, --channel <stable|nightly>  Set ARTIFACTS_CHANNEL -> releases/<channel>/<-a|latest>-artifacts.yaml.
 #                           Omit to use a local artifacts.yaml or stable/latest. See k8s/releases/VERSIONING.md.
+#   -o, --out-dir <dir>     diagnose: where to write the bundle (default ~/sandbox-run/debug/<ts>).
+#   Deploy-default overrides (opt-in; unset ⇒ prod defaults; prod never passes these):
+#       --no-atomic           install/upgrade: don't roll back on failure (keep failed pods to diagnose).
+#       --no-wait             install/upgrade: don't wait for resources to become ready.
+#       --deploy-timeout <s>  install/upgrade: helm per-release timeout in seconds (default 1200).
+#       --diagnose-on-fail    install/upgrade: auto-run `diagnose` if the deploy fails.
 #       --tui                 status: open the helm-tui terminal UI (`helm tui`).
 #       --dashboard           status: open the helm-dashboard web UI (`helm dashboard`).
 #   kubeconfig options (resolved from iac/values/secrets.env + provider.yaml when omitted):
@@ -70,7 +78,9 @@ source "$REPO_ROOT/scripts/lib/cli.sh"
 # --- arg parsing (supports -x, --x, and --x=value) -------------------------
 SUBCMD=""; RELEASE=""; FILTER=""; ASSUME_YES=0; DRYRUN=0
 STATUS_TUI=0; STATUS_DASH=0; PASSTHRU=()
-CLI_VDIR=""; CLI_ENV=""; CLI_ARTIFACTS=""; CLI_CHANNEL=""
+CLI_VDIR=""; CLI_ENV=""; CLI_ARTIFACTS=""; CLI_CHANNEL=""; CLI_OUTDIR=""
+# Helm-default overrides (opt-in; unset ⇒ helmfile's prod defaults verbatim) + diagnose-on-fail.
+HF_ATOMIC_OVERRIDE=""; HF_WAIT_OVERRIDE=""; HF_TIMEOUT_OVERRIDE=""; DIAGNOSE_ON_FAIL=0
 CLI_CLOUD=""; CLUSTER=""; PROJECT=""; REGION_F=""; ZONE_F=""; RESOURCE_GROUP=""; DO_LOGIN=0; NO_TF=0
 usage() { cli::usage "$0"; }
 die() { cli::die "$@"; }   # ❌-prefixed to stderr, exit 2 (shared lib; preserves prior exit code)
@@ -89,6 +99,13 @@ while [[ $# -gt 0 ]]; do
     --artifacts-version=*)  CLI_ARTIFACTS="${1#*=}"; shift;;
     -C|--channel) CLI_CHANNEL="${2:?--channel needs a value}"; shift 2;;
     --channel=*)  CLI_CHANNEL="${1#*=}"; shift;;
+    -o|--out-dir) CLI_OUTDIR="${2:?--out-dir needs a value}"; shift 2;;
+    --out-dir=*)  CLI_OUTDIR="${1#*=}"; shift;;
+    --no-atomic)      HF_ATOMIC_OVERRIDE="false"; shift;;
+    --no-wait)        HF_WAIT_OVERRIDE="false"; shift;;
+    --deploy-timeout) HF_TIMEOUT_OVERRIDE="${2:?--deploy-timeout needs a value (seconds)}"; shift 2;;
+    --deploy-timeout=*) HF_TIMEOUT_OVERRIDE="${1#*=}"; shift;;
+    --diagnose-on-fail) DIAGNOSE_ON_FAIL=1; shift;;
     --tui)        STATUS_TUI=1; shift;;
     --dashboard)  STATUS_DASH=1; shift;;
     -c|--cloud)   CLI_CLOUD="${2:?--cloud needs a value}"; shift 2;;
@@ -175,6 +192,9 @@ hf() {  # <diff|sync|apply|destroy|template> [extra args...]
   local -a cmd=(helmfile -f "$HELMFILE" "${SEL[@]}" "$verb" "$@" "${PASSTHRU[@]}")
   local ctx="env=${ENV_NAME:-<auto>}"; [[ -n "$ARTIFACTS_VERSION" ]] && ctx+=" ARTIFACTS_VERSION=$ARTIFACTS_VERSION"
   [[ -n "$ARTIFACTS_CHANNEL" ]] && ctx+=" ARTIFACTS_CHANNEL=$ARTIFACTS_CHANNEL"
+  [[ -n "$HF_ATOMIC_OVERRIDE" ]] && ctx+=" atomic=$HF_ATOMIC_OVERRIDE"
+  [[ -n "$HF_WAIT_OVERRIDE" ]] && ctx+=" wait=$HF_WAIT_OVERRIDE"
+  [[ -n "$HF_TIMEOUT_OVERRIDE" ]] && ctx+=" timeout=$HF_TIMEOUT_OVERRIDE"
   echo "+ (cd $VALUES_DIR && ${cmd[*]})   [$ctx]"
   [[ "$DRYRUN" -eq 1 ]] && { echo "  (dry-run: not executed)"; return 0; }
   # Drop helmfile's cached charts so OCI charts are re-pulled fresh: a stale/partial entry
@@ -189,6 +209,9 @@ hf() {  # <diff|sync|apply|destroy|template> [extra args...]
   ( cd "$BASE" && export HELMFILE_VALUES_DIR="$BASE"; \
     [[ -n "$ARTIFACTS_VERSION" ]] && export ARTIFACTS_VERSION; \
     [[ -n "$ARTIFACTS_CHANNEL" ]] && export ARTIFACTS_CHANNEL; \
+    [[ -n "$HF_ATOMIC_OVERRIDE" ]] && export HF_ATOMIC="$HF_ATOMIC_OVERRIDE"; \
+    [[ -n "$HF_WAIT_OVERRIDE" ]] && export HF_WAIT="$HF_WAIT_OVERRIDE"; \
+    [[ -n "$HF_TIMEOUT_OVERRIDE" ]] && export HF_TIMEOUT="$HF_TIMEOUT_OVERRIDE"; \
     "${cmd[@]}" )
 }
 
@@ -228,7 +251,45 @@ cmd_change() {  # <sync|apply> with auto-diff + confirm
     set +e; hf diff; set -e
     confirm "Proceed with $label?" || die "aborted"
   fi
-  hf "$verb"
+  # Plain path: no opt-in diagnose-on-fail (or a dry-run) ⇒ behave exactly as before.
+  if [[ "$DIAGNOSE_ON_FAIL" -ne 1 || "$DRYRUN" -eq 1 ]]; then
+    hf "$verb"; return $?
+  fi
+  # Opt-in path: stream AND capture so a failure can be diagnosed with the error tail in hand.
+  local log; log="$(mktemp 2>/dev/null || echo "/tmp/k8s-change.$$.log")"
+  local rc=0
+  set +e; hf "$verb" 2>&1 | tee "$log"; rc="${PIPESTATUS[0]}"; set -e
+  if [[ "$rc" -ne 0 ]]; then
+    echo "❌ $label failed (exit $rc) — capturing diagnostics…" >&2
+    run_diagnose "$log" "$rc" || true
+  fi
+  rm -f "$log" 2>/dev/null || true
+  return "$rc"
+}
+
+# Run the diagnose collector for the current release/env scope. Shared by the --diagnose-on-fail
+# auto-trigger (cmd_change) and the explicit `diagnose` verb. Always best-effort.
+run_diagnose() {  # [error_log] [exit_code]
+  local errlog="${1:-}" rc="${2:-}"
+  resolve_env
+  local outdir="${CLI_OUTDIR:-$HOME/sandbox-run/debug/$(date -u +%Y%m%d-%H%M%S)}"
+  local cmdstr="make k8s -- ${SUBCMD}${RELEASE:+ -l $RELEASE}${ENV_NAME:+ -e $ENV_NAME}"
+  # Only forward --release for a bare chart name (no '=' label) the collector can turn into <chart>-<env>.
+  local rel_arg=""; [[ -n "$RELEASE" && "$RELEASE" != *=* ]] && rel_arg="$RELEASE"
+  echo "+ k8s-diagnose.sh --out-dir $outdir${rel_arg:+ --release $rel_arg}${ENV_NAME:+ --env $ENV_NAME}"
+  [[ "$DRYRUN" -eq 1 ]] && { echo "  (dry-run: not executed)"; return 0; }
+  bash "$REPO_ROOT/scripts/k8s-diagnose.sh" \
+    --out-dir "$outdir" \
+    ${rel_arg:+--release "$rel_arg"} \
+    ${ENV_NAME:+--env "$ENV_NAME"} \
+    --command "$cmdstr" \
+    ${rc:+--exit-code "$rc"} \
+    ${errlog:+--error-log "$errlog"}
+}
+
+cmd_diagnose() {  # capture a failure artifact on demand (no deploy)
+  ensure_kubeconfig
+  run_diagnose "" ""
 }
 
 cmd_delete() {
@@ -401,6 +462,7 @@ case "$SUBCMD" in
   install)           k8s_stamped k8s-install cmd_change sync "install (helmfile sync)";;
   upgrade)           cmd_change apply "upgrade (helmfile apply)";;
   delete|destroy)    cmd_delete;;
+  diagnose)          cmd_diagnose;;
   template)          hf template;;
   status|ls)         cmd_status;;
   kubeconfig|auth)   k8s_stamped kubeconfig cmd_kubeconfig;;


### PR DESCRIPTION
## What

Makes a failed deploy *explain itself*. Today a bad release just blocks on `wait`, times out at 1200s, and `atomic: true` rolls it back — deleting the crashlooping pod, so no root cause survives. This adds a portable collector + opt-in flags so failures surface fast with the wreckage intact.

- **`scripts/k8s-diagnose.sh`** + **`make k8s -- diagnose [-l chart] [-o dir]`**: snapshots failing helm releases (`status`/`history`) and unhealthy pods (`describe` / sorted events / `logs --previous`), derives a best-effort **verdict cascade** (`HELM_RENDER` / `IMAGE_PULL` / `CONFIG_ERROR` / `CRASH_LOOP` / `SCHEDULING` / `PROBE_FAILURE` / `TIMEOUT_UNKNOWN` / `UNKNOWN`), **redacts** secret-shaped strings, and writes `summary.json` + a per-object bundle. `helm`+`kubectl`+`jq` only (no python dep); always exits 0.
- **Opt-in flags** on `install`/`upgrade`: `--no-atomic`, `--deploy-timeout <s>`, `--no-wait`, `--diagnose-on-fail` (auto-runs `diagnose` on a failed deploy).
- **`helmfile.yaml.gotmpl`**: `wait`/`timeout`/`atomic` are env-templated (`HF_WAIT`/`HF_TIMEOUT`/`HF_ATOMIC`) defaulting to today's prod values.

**Prod path is unchanged** — the overrides are opt-in and gated by the caller (sandbox/CI pass them; prod passes none), not by env name. Verified via dry-run: with no flags the helmfile invocation + ctx are byte-identical to before.

This is the deploy-side capability — a first-class `make k8s` primitive any consumer (client, nightly CI, or the sandbox `box debug`) reuses. The `summary.json` schema is the shared contract.

## Tests

`k8s-diagnose.sh` validated against stubbed `kubectl`/`helm` for CRASH_LOOP / IMAGE_PULL / HELM_RENDER / whole-stack scenarios (correct verdict, bundle, redaction). `bash -n` clean; dry-run confirms prod-unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DhNhRSmf7sG7Shkse9FprZ
