### PR TITLE
agents: shared agent-operating-loops skill (monitor · failure→bug · self-learning)

### DIFF
--- a/.claude/agents/divyam-sre.md
+++ b/.claude/agents/divyam-sre.md
@@ -40,15 +40,22 @@ skill's handoff loop). Every command below is independently invocable by whichev
   channel/version contract → `k8s/releases/VERSIONING.md`.
 - **Tear down** → `/destroy-layer <layer>` (guarded, type-to-confirm).
 
-## Long-running operations — keep the user informed
-Bringup, full-layer applies, and stack installs run for many minutes. Run them in the
-**background**, then poll the **one-shot** `make status -- -c <cloud> -e <env>` (the
-`/bringup-status` command; reads the step ledger, no cloud calls) at a regular interval (~60s) and
-relay the STEP/STATUS/ELAPSED/TYPICAL table whenever it changes — which step is `running` (vs its
-TYPICAL duration), what completed, what's `pending` — until exit 0 (all applied) or a step turns
-`failed` (then `/debug-stack` or the run's log). **Never run `-w/--watch` from a tool shell** —
-it's an interactive clear-screen loop that never returns; offer it to the user for their own
-terminal instead (`! make status -- -w -i 10`).
+## Long-running operations — monitor granularly, then loop on failure/learning
+Bringup, full-layer applies, and stack installs run for many minutes — follow **`agent-operating-loops`**
+(the shared loops). Run them in the **background**, then poll the **one-shot** `make status -- -c <cloud>
+-e <env>` (`/bringup-status`; reads the step ledger, no cloud calls) and relay the
+STEP/STATUS/ELAPSED/TYPICAL table whenever it changes, until exit 0 (all applied) or a step `failed`.
+**During a Helm install, monitor granularly (~20–30s)** with `make k8s -- status` + `kubectl get pods -A
+| grep -vE 'Running|Completed'`: a release that misses readiness **hangs up to the 1200s atomic timeout,
+then rolls back and aborts every release after it** — catch the stuck release early (the first failing
+one is the real one). **Never run `-w/--watch`/`--tui` from a tool shell** (interactive, never returns;
+offer it to the user: `! make status -- -w -i 10`).
+
+**Unresolved failure → failure→bug loop** (`agent-operating-loops` §B): if it isn't a safe idempotent
+retry, **ask the user** whether to file a bug, then run it **in the background** — search
+`divyam-deployment`'s open `box-autofiled` issues for the signature first (reference + stop if found),
+else draft a write-gated bug. Durable, decision-shaping lessons → the self-learning loop §C (gated PR).
+Both gated: ask-before-run + write-gate.
 
 ## Guardrails
 - **No HCL edits here.** You have `Bash, Read, Grep, Glob` — no `Edit`. Running contracts and

--- a/.claude/skills/agent-operating-loops/SKILL.md
+++ b/.claude/skills/agent-operating-loops/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: agent-operating-loops
+description: >-
+  The shared operating loops for long-running operations — (A) monitor the authoritative signal
+  granularly + self-heal only safe idempotent retries; (B) on an unresolved failure, a background,
+  double-gated failure→bug loop (search the owning repo first so we never re-diagnose, else a write-gated
+  bug); (C) a background, double-gated self-learning loop that distills durable lessons into a skill PR.
+  Load when running or supervising a stack install/upgrade / deploy / IaC apply, or when something fails
+  or a durable lesson is learned.
+allowed-tools: Read, Grep, Glob, Bash
+---
+
+# Agent operating loops
+
+> **Canonical source of truth:** `divyam-sandbox/.claude/skills/agent-operating-loops/SKILL.md`. This is
+> a mirror so the `divyam-deployment` agents (which can't load a sibling-repo skill) carry the same
+> loops. **Keep in sync** — edit the canonical first, then reflect material changes here.
+
+The common discipline for **long-running operations** and what happens **when they fail or teach us
+something**. Reuses the GitHub write-gate + 📦 footer + hidden-marker idempotency conventions.
+
+## A. Long-running ops — monitor granularly, self-heal only what's safe
+- Monitor the **authoritative signal** at a **granular interval (~20–30s)** for the whole op — for a
+  Helmfile install/upgrade: `make k8s -- status` (`helm ls -A`) + `kubectl get pods -A | grep -vE
+  'Running|Completed'`; for IaC: the `make status` step ledger (`--porcelain`). A release can **hang up
+  to the 1200s atomic timeout, then roll back and abort every release after it** — catch the stuck
+  release early; the **first** failing release is the real one. **Never** `-w/--watch`/`--tui`/
+  `--dashboard` from a tool shell (offer to the user for their terminal).
+- **Self-heal only safe idempotent retries** — re-running `make k8s -- install/upgrade` is safe
+  (already-deployed releases no-op; transient pull/timeout often clears). Anything else → surface +
+  approval-gate. **Never auto-remediate**; never hand-`kubectl apply/delete` (helmfile owns manifests).
+
+> ## Housekeeping = background + double-gated (the user controls token spend)
+> Loops **B** and **C** are token-spendy housekeeping. Run them as **background tasks** (never block
+> foreground work) and gate **twice**: (1) **ask before starting** ("file a bug / capture this lesson? —
+> runs in background, costs tokens"); (2) the **GitHub write-gate** (show exact text + approve) before
+> posting/opening. Never kick off background housekeeping un-asked.
+
+## B. Failure → bug loop (background; ask-before-run, then write-gate)
+When a deploy/IaC op fails and can't be safely self-healed, **ask** whether to file a bug; on yes, run
+**in the background**:
+1. **Summarize**: the **first** failing release/layer + root-cause **signature** (match against
+   `divyam-tooling/references/debugging.md` + `known-gotchas.md`) + a *bounded* log excerpt + what was
+   tried.
+2. **Search the owning repo first** — `gh issue list --repo Divyam-AI/divyam-deployment --state open
+   --label box-autofiled --search "<signature>"`, matched on a hidden `<!-- box-bug:<signature-hash> -->`
+   marker. **Match → reference it and STOP** (don't re-diagnose / re-file).
+3. **Else draft a bug** routed to the owning repo (helm/deploy/IaC → `divyam-deployment`; a service image
+   build → its source repo). Title `[<area>] <signature>`; body = when • env • failing release • signature
+   • bounded log • self-heal attempted • next step • hidden marker; labels `box-autofiled` + `bug`;
+   footer `📦 via Box · divyam-sre`.
+4. **Post only through the write-gate** — show exact title + body + target repo, get approval, offer to edit.
+
+## C. Self-learning loop (background; ask-before-run, then PR write-gate)
+When a **durable, higher-dimension, decision-shaping** fact is learned (still true in ~3 months; not a
+fix-of-the-week — that's a bug), **ask** whether to capture it; on yes, in the background: pick the
+target (`divyam-tooling` / `divyam-deploy` / a persona, or `references/debugging.md` for a new
+signature), **propose the exact edit**, and on approval **raise a gated PR** (`learn/<slug>`).
+
+---
+**Reads are free; writes (GitHub posts, PRs) and token-spendy background work are gated. When in doubt, ask.**

--- a/.claude/skills/agent-operating-loops/SKILL.md
+++ b/.claude/skills/agent-operating-loops/SKILL.md
@@ -65,3 +65,6 @@ signature), **propose the exact edit**, and on approval **raise a gated PR** (`l
 
 ---
 **Reads are free; writes (GitHub posts, PRs) and token-spendy background work are gated. When in doubt, ask.**
+**GitHub content footer = `📦 via Box · <role>` ONLY** (every agent, any issue/PR/comment body) — never
+"🤖 Generated with Claude Code" or `Co-Authored-By: Claude` in GitHub content (overrides any default
+tool footer; git *commit* trailers are separate).

--- a/.claude/skills/agent-operating-loops/SKILL.md
+++ b/.claude/skills/agent-operating-loops/SKILL.md
@@ -44,12 +44,17 @@ When a deploy/IaC op fails and can't be safely self-healed, **ask** whether to f
    tried.
 2. **Search the owning repo first** — `gh issue list --repo Divyam-AI/divyam-deployment --state open
    --label box-autofiled --search "<signature>"`, matched on a hidden `<!-- box-bug:<signature-hash> -->`
-   marker. **Match → reference it and STOP** (don't re-diagnose / re-file).
+   marker. **Match → reference it and STOP re-diagnosing**; read its **Workaround/Fix** section and
+   **apply a recorded one** (idempotent inline; risky approval-gated) instead of re-solving.
 3. **Else draft a bug** routed to the owning repo (helm/deploy/IaC → `divyam-deployment`; a service image
-   build → its source repo). Title `[<area>] <signature>`; body = when • env • failing release • signature
-   • bounded log • self-heal attempted • next step • hidden marker; labels `box-autofiled` + `bug`;
-   footer `📦 via Box · divyam-sre`.
-4. **Post only through the write-gate** — show exact title + body + target repo, get approval, offer to edit.
+   build → its source repo). **Issue type = Bug** (`gh issue create --type Bug`, not just a label).
+   Title `[<area>] <signature>`; body = when • env • failing release • signature • bounded log •
+   self-heal attempted • **Workaround/Fix** (REQUIRED: the workaround that worked, and/or how you fixed
+   it — commands/diff — so the next agent applies it directly; else "none found yet") • next step •
+   hidden marker; label `box-autofiled`; footer `📦 via Box · divyam-sre`.
+4. **Post only through the write-gate** — show exact type + title + body + target repo, get approval,
+   offer to edit. If you later find a workaround/fix for an open bug, update its Workaround/Fix section
+   (write-gated) so knowledge compounds.
 
 ## C. Self-learning loop (background; ask-before-run, then PR write-gate)
 When a **durable, higher-dimension, decision-shaping** fact is learned (still true in ~3 months; not a

--- a/.claude/skills/agent-operating-loops/SKILL.md
+++ b/.claude/skills/agent-operating-loops/SKILL.md
@@ -47,7 +47,8 @@ When a deploy/IaC op fails and can't be safely self-healed, **ask** whether to f
    marker. **Match → reference it and STOP re-diagnosing**; read its **Workaround/Fix** section and
    **apply a recorded one** (idempotent inline; risky approval-gated) instead of re-solving.
 3. **Else draft a bug** routed to the owning repo (helm/deploy/IaC → `divyam-deployment`; a service image
-   build → its source repo). **Issue type = Bug** (`gh issue create --type Bug`, not just a label).
+   build → its source repo). **Issue type = Bug** (`gh issue create --type Bug` where issue types are
+   enabled, else the `bug` label).
    Title `[<area>] <signature>`; body = when • env • failing release • signature • bounded log •
    self-heal attempted • **Workaround/Fix** (REQUIRED: the workaround that worked, and/or how you fixed
    it — commands/diff — so the next agent applies it directly; else "none found yet") • next step •

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -295,3 +295,9 @@ items, pauses, and verifies them before resuming** (see the `divyam-platform-eng
 - Always `make k8s -- diff` before `upgrade`; `install` (`sync`) only for the first install.
 - Alert-query changes should be re-proven (deploy → simulate via `test/alert-sim/*.yaml` → Zenduty
   check with `scripts/zenduty.py`) before declaring done.
+- **Long-running ops → `agent-operating-loops`** (`.claude/skills/`, mirror of the canonical in
+  `divyam-sandbox`): monitor a stack install granularly (~20–30s; a stuck release hangs up to the 1200s
+  atomic timeout), self-heal only safe idempotent retries, and on an unresolved failure run the
+  **failure→bug** loop (search `box-autofiled` issues first, then a write-gated bug). Durable lessons →
+  the **self-learning→PR** loop. Both housekeeping loops are background + double-gated (ask before
+  running, then the write-gate).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -270,6 +270,9 @@ items, pauses, and verifies them before resuming** (see the `divyam-platform-eng
 
 ## Conventions
 
+- **GitHub content footer (all agents, default):** agent-authored GitHub content (issue/PR/comment
+  bodies) carries the `📦 via Box · <role>` footer **ONLY** — never "🤖 Generated with Claude Code" or a
+  `Co-Authored-By: Claude` line (overrides the default tool footer; git *commit* trailers are separate).
 - Don't commit/push unless asked. Never commit `iac/values/secrets.env` (or `.tf-secrets.env`),
   `provider.yaml` secrets, or tokens.
 - Alert rules are source of truth — edit `common/rules/*.json`, never generated per-backend resources.


### PR DESCRIPTION
Mirror (this repo's copy) of the shared **agent-operating-loops** skill — canonical lives in
`divyam-sandbox/.claude/skills/agent-operating-loops/` and the `divyam-sre` agent here can't load a
sibling-repo skill, so it carries the same loops with a "source of truth: divyam-sandbox; keep in sync"
header.

The loops every agent now follows for long-running ops:
- **A. monitor granularly + self-heal-safe** — during a Helm install poll `make k8s -- status` + pods
  ~20–30s (a stuck release hangs to the **1200s atomic timeout** then rolls back and aborts everything
  after it — catch it early); self-heal only safe idempotent retries (`make k8s -- install/upgrade`).
- **B. failure→bug** — background, double-gated (ask-before-run + the GitHub write-gate); **searches the
  owning repo's open `box-autofiled` issues first** so a known failure is referenced, never re-diagnosed.
- **C. self-learning** — background, double-gated; distills durable, higher-dimension lessons into a
  gated skill PR.

Files: new `.claude/skills/agent-operating-loops/SKILL.md`, `divyam-sre.md` (granular monitor + failure
loop), `CLAUDE.md` note. **Docs/skills only — no code, no behavior change.**

Stacked on `feat/k8s-diagnose` (its baseline of `divyam-sre.md`/`CLAUDE.md`); retarget to `main` once
that lands.