### PR TITLE
infra-ops/debugging: single-node anti-affinity + golden-image kubelet-cert recovery runbooks (feature #143)

### DIFF
--- a/.claude/skills/divyam-tooling/references/debugging.md
+++ b/.claude/skills/divyam-tooling/references/debugging.md
@@ -44,6 +44,19 @@ To inspect a release that keeps getting rolled back, retry with atomic off / a l
 failed pod survives for `describe`/`logs`: `make k8s -- upgrade -l <chart> -- --no-atomic --timeout 300s`
 (args after a second `--` pass straight to helmfile/helm; confirm with `./scripts/k8s.sh help`).
 
+### Single-node: rollback from HARD pod anti-affinity + surge
+**Symptom:** on a single-node cluster (sandbox MicroK8s), `helm upgrade` of `divyam-route-selector` /
+`divyam-router-controller` hangs to the progress-deadline then rolls back; the new pod is `Pending`
+with `didn't match pod anti-affinity rules`.
+**Cause:** charts default to `requiredDuringSchedulingIgnoredDuringExecution` (HARD) pod anti-affinity
++ RollingUpdate `maxSurge>0`; the surge pod can't co-schedule with the incumbent on one node → never
+schedulable → deadline → rollback. These charts **don't honor `.Values.strategy`** (can't force
+`Recreate`).
+**Fix (sandbox):** (1) override to SOFT affinity via the chart's `.Values.affinity` passthrough —
+present only in SOURCE charts, not published (divyam-helm-charts#72 / gap `G-CHART-AFFINITY-PUBLISH`),
+so needs a `source` box; or (2) **scale the release to 0, then redeploy** to clear the HARD incumbent.
+Proper fix: a `.Values.strategy` passthrough — divyam-helm-charts#73.
+
 ### ExternalSecret / secrets not resolving
 The secret chain: `provider.yaml` `secrets:` → **external-secrets-operator** → `SecretStore` →
 `ExternalSecret` → the k8s `Secret` a chart mounts. Charts only render an ExternalSecret when

--- a/.claude/skills/divyam-tooling/references/infra-ops.md
+++ b/.claude/skills/divyam-tooling/references/infra-ops.md
@@ -177,3 +177,16 @@ mysql -h mysql-<env>-svc -uroot -p -e "SELECT 1; SHOW STATUS LIKE 'Threads_conne
 - k8s-values `resources.yaml`: cpu/mem (buffer pool), storage, `max_connections`. **Back up before any
   upgrade (single node).** **Reliability gap: no replication/failover for a serving-critical store —
   candidate for an HA change.**
+
+## MicroK8s host (single-node sandbox) — golden-image clone cert/node drift
+Cloned-from-golden-image sandbox VMs inherit **bake-time** node identity. Two failures appear together:
+a stale `microk8s-node` stuck **NotReady** (wrong IP), and `kubectl logs`/`exec` failing **x509**
+because the kubelet **serving** cert carries the bake-time node IP in its SAN.
+**Critical traps:** `microk8s refresh-certs` does **NOT** cover the kubelet serving cert; the snap's
+`create_user_certificates` **aborts** (`REAL_PATH: unbound variable`) and **truncates** the user certs
+— don't use it.
+**Recovery (working):** (1) from the intact private keys + cluster CA, re-sign all user/serving certs
+with `openssl`, correct **EKU** per cert (`serverAuth` kubelet serving / `clientAuth` clients) + the
+**live** node IP/hostname in the SAN; (2) re-embed the certs into the kubeconfigs; (3) restart
+`microk8s.daemon-kubelite`; (4) verify one node Ready + `kubectl logs <pod>` no longer x509. Durable
+fix (regenerate identity + serving cert at clone first-boot): divyam-sandbox#23. Gap `G-CLONE-KUBELET-CERT`.


### PR DESCRIPTION
- **debugging.md** — new "Single-node: rollback from HARD pod anti-affinity + surge" runbook: single-node `helm upgrade` of route-selector/router-controller rolls back because HARD pod anti-affinity + surge can't co-schedule; fix via SOFT-affinity passthrough (source charts only) or scale-to-0-then-redeploy.
- **infra-ops.md** — new "MicroK8s host — golden-image clone cert/node drift" section: cloned VMs inherit bake-time node identity (NotReady node + x509 on kubelet serving cert); `refresh-certs`/`create_user_certificates` don't fix it — recover by openssl re-signing user/serving certs with correct EKU + live SAN, re-embedding into kubeconfigs, and restarting kubelite.

Refs: divyam-helm-charts#72, divyam-helm-charts#73, divyam-sandbox#23

---
📦 via Box · feature #143 · divyam-sre