### PR TITLE
feat(helmfile): wire argilla-ingress and decouple ingress charts from core

### DIFF
--- a/k8s/helm-values/sample-config.yaml
+++ b/k8s/helm-values/sample-config.yaml
@@ -119,9 +119,8 @@ evalm8-ingress:
       domain:
         evalm8: ""        # required per env: "evalm8.<env>.divyam.local"
 
-# Argilla owns its own ingress (annotation UI, backend :6900). Gated per provider
-# and per env. The worker stays internal.
-argilla:
+# argilla-ingress: Argilla annotation UI/API (backend :6900). Separate ingress chart, gated per provider and per env. The worker stays internal.
+argilla-ingress:
   values:
     ingress:
       deploy: true

--- a/k8s/helm-values/sample-resources.yaml
+++ b/k8s/helm-values/sample-resources.yaml
@@ -415,3 +415,6 @@ charts:
   evalm8-ingress:
     values: {}
 
+  argilla-ingress:
+    values: {}
+

--- a/k8s/helmfile.yaml.gotmpl
+++ b/k8s/helmfile.yaml.gotmpl
@@ -184,6 +184,7 @@ repositories:
   "argilla-postgres"                      "argilla"
   "argilla-opensearch"                    "argilla"
   "argilla-redis"                         "argilla"
+  "argilla-ingress"                       "argilla"
 
   "evalm8-server"                         "evalm8"
   "evalm8-wfs"                            "evalm8"
@@ -247,7 +248,7 @@ repositories:
   "superset-ingress"                  true
   "divyam-router-controller-ingress"  true
   "evalm8-ingress"                    true
-  "argilla"                           true
+  "argilla-ingress"                   true
 -}}
 
 {{/*
@@ -348,6 +349,7 @@ repositories:
   "temporal"                      (list "temporal-postgres")
   "lakefs"                        (list "lakefs-postgres" "external-secrets-operator")
   "argilla"                       (list "argilla-postgres" "argilla-opensearch" "argilla-redis" "external-secrets-operator")
+  "argilla-ingress"               (list "argilla")
   "evalm8-server"                 (list "temporal" "lakefs" "argilla" "mysql" "external-secrets-operator")
   "evalm8-wfs"                    (list "temporal" "lakefs" "argilla" "mysql" "external-secrets-operator" "evalm8-server")
   "evalm8-ui"                     (list "evalm8-server")

--- a/k8s/helmfile.yaml.gotmpl
+++ b/k8s/helmfile.yaml.gotmpl
@@ -350,8 +350,8 @@ repositories:
   "lakefs"                        (list "lakefs-postgres" "external-secrets-operator")
   "argilla"                       (list "argilla-postgres" "argilla-opensearch" "argilla-redis" "external-secrets-operator")
   "argilla-ingress"               (list "argilla")
-  "evalm8-server"                 (list "temporal" "lakefs" "argilla" "mysql" "external-secrets-operator")
-  "evalm8-wfs"                    (list "temporal" "lakefs" "argilla" "mysql" "external-secrets-operator" "evalm8-server")
+  "evalm8-server"                 (list "temporal" "lakefs" "argilla" "argilla-ingress" "mysql" "external-secrets-operator")
+  "evalm8-wfs"                    (list "temporal" "lakefs" "argilla" "argilla-ingress" "mysql" "external-secrets-operator" "evalm8-server")
   "evalm8-ui"                     (list "evalm8-server")
   "evalm8-ingress"                (list "evalm8-server" "evalm8-ui")
 

--- a/k8s/helmfile.yaml.gotmpl
+++ b/k8s/helmfile.yaml.gotmpl
@@ -280,11 +280,8 @@ repositories:
   "divyam-router-controller"      true
   "divyam-route-selector"         true
   "infinity"                      true
-  "evalm8-server"                 true
-  "evalm8-ui"                     true
   "temporal"                      true
   "lakefs"                        true
-  "argilla"                       true
 -}}
 
 {{/*

--- a/k8s/helmfile.yaml.gotmpl
+++ b/k8s/helmfile.yaml.gotmpl
@@ -346,11 +346,11 @@ repositories:
   "temporal"                      (list "temporal-postgres")
   "lakefs"                        (list "lakefs-postgres" "external-secrets-operator")
   "argilla"                       (list "argilla-postgres" "argilla-opensearch" "argilla-redis" "external-secrets-operator")
-  "argilla-ingress"               (list "argilla")
-  "evalm8-server"                 (list "temporal" "lakefs" "argilla" "argilla-ingress" "mysql" "external-secrets-operator")
-  "evalm8-wfs"                    (list "temporal" "lakefs" "argilla" "argilla-ingress" "mysql" "external-secrets-operator" "evalm8-server")
+  "argilla-ingress"               (list)
+  "evalm8-server"                 (list "temporal" "lakefs" "argilla" "mysql" "external-secrets-operator")
+  "evalm8-wfs"                    (list "temporal" "lakefs" "argilla" "mysql" "external-secrets-operator" "evalm8-server")
   "evalm8-ui"                     (list "evalm8-server")
-  "evalm8-ingress"                (list "evalm8-server" "evalm8-ui")
+  "evalm8-ingress"                (list)
 
 -}}
 


### PR DESCRIPTION
## Summary

Wire the argilla-ingress release and decouple the ingress charts from the core they front.

- Add argilla-ingress to the namespace-group map (argilla), the evalm8 stack, and the provider-ingress set.
- evalm8-server and evalm8-wfs depend on argilla (the core chart that owns `argilla-<env>-svc`), not on argilla-ingress.
- argilla-ingress and evalm8-ingress declare no needs edge to the core they front. Each owns only the external Service and references the core pods by label, so no deploy ordering against the core is required.
- Move the per-provider ingress config from the argilla values block to argilla-ingress in the sample values.

## Pairs with

Divyam-AI/divyam-helm-charts#76 (argilla Service split). The core chart owns the internal ClusterIP `argilla-<env>-svc` and argilla-ingress owns the external `argilla-<env>-ext-svc`. Merge the chart PR first or together, so main never points internal consumers at a Service the core does not yet own.

## Validation (sandbox, on-cluster)

- argilla split deployed clean: core ClusterIP `argilla-sandbox-svc` plus ingress NodePort `argilla-sandbox-ext-svc`, distinct Helm owners, both select `app=argilla-server`.
- evalm8-server resolves `dependencies.argilla` to `argilla-sandbox-svc` (the core Service).
- `helmfile build` green (stack=both, MICROK8S).

Part of #58.
