### PR TITLE
fix(k8s): skip helm-diff on newly-installed releases

### DIFF
--- a/scripts/k8s.sh
+++ b/scripts/k8s.sh
@@ -246,6 +246,12 @@ ensure_kubeconfig() {
 cmd_change() {  # <sync|apply> with auto-diff + confirm
   local verb="$1" label="$2"
   ensure_kubeconfig
+  # On apply, skip helm-diff for releases being newly installed.
+  # A brand-new release whose CRD comes from another release in the same run cannot be server-dry-run diffed before that operator installs, so the diff aborts with "no matches for kind" (lakefs-postgres needs the cloudnative-pg-operator CRD).
+  # needs still orders the sync so the operator installs first, which makes the skipped install-time diff safe.
+  # sync has no diff phase, so the flag applies only to apply.
+  local -a verb_extra=()
+  [[ "$verb" == apply ]] && verb_extra+=(--skip-diff-on-install)
   if [[ "$ASSUME_YES" -ne 1 && "$DRYRUN" -ne 1 ]]; then
     echo "-- diff preview before $label --"
     set +e; hf diff; set -e
@@ -253,12 +259,12 @@ cmd_change() {  # <sync|apply> with auto-diff + confirm
   fi
   # Plain path: no opt-in diagnose-on-fail (or a dry-run) ⇒ behave exactly as before.
   if [[ "$DIAGNOSE_ON_FAIL" -ne 1 || "$DRYRUN" -eq 1 ]]; then
-    hf "$verb"; return $?
+    hf "$verb" "${verb_extra[@]}"; return $?
   fi
   # Opt-in path: stream AND capture so a failure can be diagnosed with the error tail in hand.
   local log; log="$(mktemp 2>/dev/null || echo "/tmp/k8s-change.$$.log")"
   local rc=0
-  set +e; hf "$verb" 2>&1 | tee "$log"; rc="${PIPESTATUS[0]}"; set -e
+  set +e; hf "$verb" "${verb_extra[@]}" 2>&1 | tee "$log"; rc="${PIPESTATUS[0]}"; set -e
   if [[ "$rc" -ne 0 ]]; then
     echo "❌ $label failed (exit $rc) — capturing diagnostics…" >&2
     run_diagnose "$log" "$rc" || true


### PR DESCRIPTION
## Problem

The preprod nightly failed on `helmfile apply` with:

```
Error: Failed to render chart: ... unable to build kubernetes objects from release manifest:
resource mapping not found for name: "lakefs-postgres-preprod" ...
no matches for kind "Cluster" in version "postgresql.cnpg.io/v1"
ensure CRDs are installed first
```

`helmfile apply` diffs **every** release up front (before syncing any). `helmDefaults.diffArgs` uses `--dry-run=server`, so the apiserver REST-maps each rendered manifest. `lakefs-postgres` (also `argilla-postgres`, `temporal-postgres`) render a CNPG `Cluster` (`postgresql.cnpg.io/v1`) whose CRD ships with the `cloudnative-pg-operator` release. On the first apply that introduces the evalm8 datastore stack, that operator is not yet installed, the CRD is absent, and the server dry-run aborts.

`needs` orders the **sync**, not the **diff**, so it does not help the diff phase.

Confirmed CRD-presence-gated, not a code regression: the Altinity `ClickHouseInstallation` CRs diff fine in the same run because that operator + CRDs already exist in preprod. CNPG is net-new.

## Fix

Pass `--skip-diff-on-install` on the `apply` path in `cmd_change` (`scripts/k8s.sh`). Not-yet-installed releases skip the install-time diff, so the missing CRD is never server-dry-run validated. The `needs` graph still installs `cloudnative-pg-operator` before its `Cluster` CRs, so the CRD is registered before the Cluster is applied. `sync` has no diff phase, so the flag is scoped to `apply` only.

## Testing

- `bash -n scripts/k8s.sh` clean.
- `make k8s -- upgrade -n` prints `helmfile ... apply ... --skip-diff-on-install`; `make k8s -- install -n` does not (sync path).
- End-to-end: re-run the preprod nightly (the exact failing pipeline) and confirm it gets past the `lakefs-postgres` diff.

Flag exists on the pinned helmfile (`--skip-diff-on-install` predates v1; verified on v1.5.5).