### PR TITLE
feat(helmfile): map provider.yaml evalm8.storage to lakefs objectStorage

### DIFF
--- a/k8s/helmfile.yaml.gotmpl
+++ b/k8s/helmfile.yaml.gotmpl
@@ -559,6 +559,26 @@ releases:
     - deployment_mode: {{ $deploymentMode | quote }}
     {{- end }}
 
+    {{- /* Map the evalm8.storage block from provider.yaml to the lakefs chart objectStorage, the chart single source of truth. */}}
+    {{- /* provider.yaml uses the platform-block vocabulary (provider GCP|PVC|AZURE|S3), the chart uses type gcs|local|azure|s3. */}}
+    {{- /* An absent block leaves the chart default of local, so terraform decides the backend per environment. */}}
+    {{- if eq $name "lakefs" }}
+    {{- $storage := (index $values.global "evalm8" | default dict).storage | default dict }}
+    {{- if $storage.provider }}
+    {{- $sp := $storage.provider | upper }}
+    {{- $os := dict "type" "local" }}
+    {{- if eq $sp "GCP" }}
+    {{- $os = dict "type" "gcs" "gcs" (dict "bucket" (((index $storage "gcp" | default dict).storage_configs | default dict).bucket | default "")) }}
+    {{- else if eq $sp "S3" }}
+    {{- $os = dict "type" "s3" "s3" (dict "bucket" (((index $storage "s3" | default dict).storage_configs | default dict).bucket | default "") "region" (((index $storage "s3" | default dict).storage_configs | default dict).region | default "")) }}
+    {{- else if eq $sp "AZURE" }}
+    {{- $os = dict "type" "azure" "azure" (dict "account" (((index $storage "azure" | default dict).storage_configs | default dict).account | default "") "container" (((index $storage "azure" | default dict).storage_configs | default dict).container | default "")) }}
+    {{- end }}
+    - objectStorage:
+      {{ $os | toYaml | nindent 8 }}
+    {{- end }}
+    {{- end }}
+
     {{- $chartVals := $cfg.values | default dict }}
     {{- $omitProviderKeys := false }}
     {{- if or (hasKey $chartsWithProviderIngress $name) (hasKey $chartsWithProviderMonitoring $name) (hasKey $chartsWithProviderSecrets $name) }}


### PR DESCRIPTION
## What

Maps the evalm8.storage block from provider.yaml into the lakefs release as objectStorage, the chart single source of truth (see Divyam-AI/divyam-helm-charts#85).

provider.yaml carries the backend as a platform-style block:

```yaml
evalm8:
  storage:
    provider: GCP   # GCP | PVC | AZURE | S3
    gcp:
      storage_configs:
        bucket: <env>-lakefs
```

The helmfile translates that to the lakefs chart values:

```yaml
objectStorage:
  type: gcs         # gcs | local | azure | s3
  gcs:
    bucket: <env>-lakefs
```

provider PVC maps to type local, S3 and AZURE map to s3 and azure with their buckets/accounts.
An absent block emits nothing, so the chart keeps its local default.

## Verification

helmfile build against the gcp-preprod values renders the lakefs release with:

```yaml
- objectStorage:
    gcs:
      bucket: divyam-preprod-lakefs
    type: gcs
```

## Note

provider.yaml is generated by terraform (iac/2-app/3-export_details/{gcp,azure}/main.tf).
For the block to survive a regeneration, the export template must also emit evalm8.storage from a lakefs bucket variable.
That iac change and the per-env provider.yaml values are tracked separately.

Pairs with Divyam-AI/divyam-helm-charts#85 and Divyam-AI/divyam_router_cd#317.

Refs #58, Divyam-AI/divyam-helm-charts#84
