### PR TITLE
fix(helmfile): add argilla to evalm8-ui dependencies

### DIFF
--- a/k8s/helmfile.yaml.gotmpl
+++ b/k8s/helmfile.yaml.gotmpl
@@ -349,7 +349,7 @@ repositories:
   "argilla-ingress"               (list)
   "evalm8-server"                 (list "temporal" "lakefs" "argilla" "mysql" "external-secrets-operator")
   "evalm8-wfs"                    (list "temporal" "lakefs" "argilla" "mysql" "external-secrets-operator" "evalm8-server")
-  "evalm8-ui"                     (list "evalm8-server")
+  "evalm8-ui"                     (list "evalm8-server" "argilla")
   "evalm8-ingress"                (list)
 
 -}}


### PR DESCRIPTION
## What

Add `argilla` to the evalm8-ui dependency list in the helmfile so the evalm8-ui chart receives `dependencies.argilla` (the argilla service DNS).

## Why

The evalm8-ui nginx reverse-proxies `/annotations` to the argilla service. The chart now derives that proxy target (and `/api`) from the injected `dependencies` map with an environment fallback, instead of a hardcoded `printf`. Declaring the dependency makes the injected value authoritative. Addresses a review comment on Divyam-AI/divyam-helm-charts#95.

## Impact

Dependency-map only. Adds an ordering edge (evalm8-ui waits on argilla) and injects the DNS. No behavior change to other charts.