### PR TITLE
chore(helmfile): remove argilla-ingress from the stack maps

### DIFF
--- a/k8s/helmfile.yaml.gotmpl
+++ b/k8s/helmfile.yaml.gotmpl
@@ -184,7 +184,6 @@ repositories:
   "argilla-postgres"                      "argilla"
   "argilla-opensearch"                    "argilla"
   "argilla-redis"                         "argilla"
-  "argilla-ingress"                       "argilla"
 
   "evalm8-server"                         "evalm8"
   "evalm8-wfs"                            "evalm8"
@@ -248,7 +247,6 @@ repositories:
   "superset-ingress"                  true
   "divyam-router-controller-ingress"  true
   "evalm8-ingress"                    true
-  "argilla-ingress"                   true
 -}}
 
 {{/*
@@ -346,7 +344,6 @@ repositories:
   "temporal"                      (list "temporal-postgres")
   "lakefs"                        (list "lakefs-postgres" "external-secrets-operator")
   "argilla"                       (list "argilla-postgres" "argilla-opensearch" "argilla-redis" "external-secrets-operator")
-  "argilla-ingress"               (list)
   "evalm8-server"                 (list "temporal" "lakefs" "argilla" "mysql" "external-secrets-operator")
   "evalm8-wfs"                    (list "temporal" "lakefs" "argilla" "mysql" "external-secrets-operator" "evalm8-server")
   "evalm8-ui"                     (list "evalm8-server")

--- a/k8s/helmfile.yaml.gotmpl
+++ b/k8s/helmfile.yaml.gotmpl
@@ -247,6 +247,8 @@ repositories:
   "superset-ingress"                  true
   "divyam-router-controller-ingress"  true
   "evalm8-ingress"                    true
+  "evalm8-server"                     true
+  "evalm8-wfs"                        true
 -}}
 
 {{/*


### PR DESCRIPTION
## What

Remove the three argilla-ingress entries from k8s/helmfile.yaml.gotmpl (namespaceGroupMap, chartsWithProviderIngress, dependencyMap).

## Why

argilla-ingress is no longer deployed in any env. It was removed from the router_cd artifacts/resources/config (prod and preprod), so no release is generated for it. Argilla is reached in-cluster via the evalm8-ui nginx /annotations reverse proxy, so the argilla-ingress chart is not needed. The chart itself stays in divyam-helm-charts for a possible future standalone argilla exposure on its own DNS.

These map entries were inert (a chart only becomes a release when present in the merged values / artifacts.yaml), so this is dead-config cleanup with no behavior change. Verified helmfile parses and lists no argilla-ingress release.

## Related
- divyam-helm-charts #95 (charts), divyam_router_cd #322 (values), divyam-deployment #93 (prod infra prereqs).