### PR TITLE
fix(azure): enable managed Prometheus in IaC + emit provider.yaml stack

### DIFF
--- a/iac/1-platform/1-k8s/azure/main.tf
+++ b/iac/1-platform/1-k8s/azure/main.tf
@@ -170,6 +170,16 @@ resource "azurerm_kubernetes_cluster" "aks_cluster" {
     }
   }
 
+  # Managed Prometheus addon: flips azureMonitorProfile.metrics.enabled=true and rolls out the
+  # ama-metrics scrapers + azmonitoring.coreos.com CRDs. Routing (Azure Monitor Workspace + DCR +
+  # association) is owned by 1-platform/2-monitoring/native. Unlike `az aks update`, this block does
+  # NOT auto-create a DCR, so it does not conflict with that module's DCR.
+  dynamic "monitor_metrics" {
+    for_each = var.create && var.enable_metrics_collection ? { "enabled" = true } : {}
+
+    content {}
+  }
+
   tags = local.rendered_tags_cluster
 
   lifecycle {

--- a/iac/1-platform/1-k8s/azure/terragrunt.hcl
+++ b/iac/1-platform/1-k8s/azure/terragrunt.hcl
@@ -89,7 +89,7 @@ inputs = {
   nat_resource_group_name = try(local.root.nat.nat_resource_group_name, null)
 
   enable_log_collection     = local.datadog_enabled ? false : try(local.obs.enable_logs, true)
-  enable_metrics_collection = false
+  enable_metrics_collection = local.datadog_enabled ? false : try(local.obs.enable_metrics, true)
   logs_retention_days       = min(730, try(local.obs.logs_retention_days, 730))
   artifacts_path           = try(local.root.helm_charts.artifacts_path, null)
 }

--- a/iac/2-app/3-export_details/azure/main.tf
+++ b/iac/2-app/3-export_details/azure/main.tf
@@ -37,11 +37,16 @@ monitoring:
 
 EOT
 
+  # Stack selector consumed by k8s/helmfile.yaml.gotmpl (evalm8 | router | both). Emitted only when
+  # set; an absent key makes helmfile deploy every stack (its documented default). This replaces the
+  # previously-manual `stack: router` edit that each regen used to wipe.
+  stack_block = trimspace(var.stack) != "" ? "stack: ${var.stack}\n\n" : ""
+
   platform_block = <<-EOT
 # Global config and platform provider (Azure)
 # Combined with resources.yaml and artifacts.yaml via helmfile
 
-environment: ${var.environment}
+${local.stack_block}environment: ${var.environment}
 ${local.monitoring_block}
 platform:
   provider: AZURE

--- a/iac/2-app/3-export_details/azure/terragrunt.hcl
+++ b/iac/2-app/3-export_details/azure/terragrunt.hcl
@@ -119,6 +119,7 @@ inputs = {
   image_pull_secret_enabled = try(local.export_cfg.image_pull_secret_enabled, true)
   monitoring_enabled        = local.monitoring_enabled
   monitoring_provider       = local.monitoring_provider
+  stack                     = try(local.root.stack, "")
   output_path               = "${local.repo_root}/${try(local.export_cfg.output_dir, "k8s/values")}/provider.yaml"
 
   ingress_deploy             = true

--- a/iac/2-app/3-export_details/azure/variables.tf
+++ b/iac/2-app/3-export_details/azure/variables.tf
@@ -123,6 +123,16 @@ variable "monitoring_provider" {
   default     = ""
 }
 
+variable "stack" {
+  description = "Which chart stack helmfile deploys, written to provider.yaml as top-level `stack`: evalm8 | router | both. Empty omits the key (helmfile then deploys all stacks)."
+  type        = string
+  default     = ""
+  validation {
+    condition     = contains(["", "evalm8", "router", "both"], var.stack)
+    error_message = "stack must be one of: evalm8, router, both (or empty to omit the key)."
+  }
+}
+
 variable "output_path" {
   description = "Absolute path for the generated provider.yaml file."
   type        = string

--- a/iac/2-app/3-export_details/gcp/main.tf
+++ b/iac/2-app/3-export_details/gcp/main.tf
@@ -33,11 +33,16 @@ monitoring:
 
 EOT
 
+  # Stack selector consumed by k8s/helmfile.yaml.gotmpl (evalm8 | router | both). Emitted only when
+  # set; an absent key makes helmfile deploy every stack (its documented default). This replaces the
+  # previously-manual `stack: router` edit that each regen used to wipe.
+  stack_block = trimspace(var.stack) != "" ? "stack: ${var.stack}\n\n" : ""
+
   platform_block = <<-EOT
 # Global config and platform provider (GCP)
 # Combined with resources.yaml and artifacts.yaml via helmfile
 
-environment: ${var.environment}
+${local.stack_block}environment: ${var.environment}
 ${local.monitoring_block}
 platform:
   provider: GCP

--- a/iac/2-app/3-export_details/gcp/terragrunt.hcl
+++ b/iac/2-app/3-export_details/gcp/terragrunt.hcl
@@ -81,6 +81,7 @@ inputs = {
   image_pull_secret_enabled = try(local.export_cfg.image_pull_secret_enabled, false)
   monitoring_enabled        = local.monitoring_enabled
   monitoring_provider       = local.monitoring_provider
+  stack                     = try(local.root.stack, "")
   output_path               = "${local.repo_root}/${try(local.export_cfg.output_dir, "k8s/values")}/provider.yaml"
 
   cloudsql_created = local.cloudsql_created

--- a/iac/2-app/3-export_details/gcp/variables.tf
+++ b/iac/2-app/3-export_details/gcp/variables.tf
@@ -93,6 +93,16 @@ variable "monitoring_provider" {
   default     = ""
 }
 
+variable "stack" {
+  description = "Which chart stack helmfile deploys, written to provider.yaml as top-level `stack`: evalm8 | router | both. Empty omits the key (helmfile then deploys all stacks)."
+  type        = string
+  default     = ""
+  validation {
+    condition     = contains(["", "evalm8", "router", "both"], var.stack)
+    error_message = "stack must be one of: evalm8, router, both (or empty to omit the key)."
+  }
+}
+
 variable "output_path" {
   description = "Absolute path for the generated provider.yaml file."
   type        = string


### PR DESCRIPTION
## Why

While switching an AKS sandbox from Datadog to Azure Managed Prometheus, two IaC gaps forced out-of-band manual steps on **every** apply — `az aks update` to turn on the addon, and hand-editing `provider.yaml`. This makes a plain IaC re-run sufficient (no `az`, no manual edits).

## 1 · Dead `enable_metrics_collection` variable — `1-platform/1-k8s/azure`

The variable was declared but **never referenced in `main.tf`**, so the AKS cluster never got `azureMonitorProfile.metrics.enabled=true` and the `ama-metrics` scrapers were never rolled out. This is a regression from the `iac/` restructure, which correctly relocated the AMW/DCR/association to `2-monitoring/native/azure` but dropped the cluster addon block. (The pre-restructure `azure/aks` module still had it wired.)

- **`main.tf`** — add a `monitor_metrics {}` dynamic block gated on `enable_metrics_collection`. Unlike `az aks update`, Terraform's block does **not** auto-create a DCR, so `2-monitoring/native` stays the single DCR owner — no duplicate-DCR conflict.
- **`terragrunt.hcl`** — wire `enable_metrics_collection` to the observability flag (`datadog off → k8s.observability.enable_metrics`, default `true`), mirroring `enable_log_collection`.

## 2 · `provider.yaml` didn't emit the helmfile `stack` selector — `2-app/3-export_details` (azure + gcp)

The generated `provider.yaml` omitted the top-level `stack` key that `k8s/helmfile.yaml.gotmpl` consumes, so the manual `stack: router` line was wiped on every regen. Now emitted from Terraform (both clouds, since `stack` is cloud-agnostic):

- **`variables.tf`** — new validated `stack` variable (`evalm8 | router | both | ""`).
- **`main.tf`** — prepend `stack: <value>` when set; **empty omits the key** (helmfile's documented "deploy all" default), so existing envs render byte-for-byte identical.
- **`terragrunt.hcl`** — pass `stack = try(local.root.stack, "")`.

## Resulting client switch

Set `datadog.enabled=false` and `stack="router"` in the env values file, then:
```
make iac -- apply -l 1-platform   # 1-k8s enables addon → 2-monitoring creates AMW+DCR+assoc
make iac -- apply -l 2-app         # regenerates provider.yaml WITH stack: router
make k8s -- upgrade
```

## Validation

- `tofu fmt` parses all files; no new misalignment introduced.
- Confirmed **azurerm 4.73.0** supports the `monitor_metrics` block (`annotations_allowed`/`labels_allowed`, both optional).
- Rendered `provider.yaml` both ways: `stack=router` → top-level `stack: router`; empty default → identical to today.
- `monitor_metrics` on an existing cluster is an **in-place** update (additive; no cluster replacement).

## ⚠️ Note for the existing POC sandbox only

That cluster already carries the `az`-created `MSProm-*` DCR/DCE + `divyam-sandbox-amw` (not in TF state). Applying this on **that** cluster would create a second, TF-managed DCR → duplicate DCRs. Delete or `terragrunt run -- import` the ad-hoc `az` resources first. A fresh client cluster (Datadog-only today) has nothing to collide with, so its path is clean.
