### PR TITLE
Add divyam-redis service name override

### DIFF
--- a/k8s/helmfile.yaml.gotmpl
+++ b/k8s/helmfile.yaml.gotmpl
@@ -361,6 +361,7 @@ repositories:
   "clickhouse" "clickhouse-clk-%s"
   "divyam-route-selector" "route-selector-%s-svc"
   "divyam-router-controller" "router-controller-%s-svc"
+  "divyam-redis" "redis-%s-service"
   "temporal"                "temporal-%s-svc"
   "lakefs"                  "lakefs-%s-svc"
   "argilla"                 "argilla-%s-svc"


### PR DESCRIPTION
Maps divyam-redis to its actual service redis-<env>-service in the helmfile service-name override map, so selector-training's redis dependency DNS resolves correctly (default would be divyam-redis-<env>-svc, which does not exist).

Companion to Divyam-AI/divyam-helm-charts#109.

Divyam-AI/divyam_route_selector#182